### PR TITLE
Improve destructors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,4 @@ mod layers_surface_wrapper;
 pub use layers_surface_wrapper::LayersSurfaceWrapper;
 
 #[cfg(test)]
-#[cfg(target_os="macos")]
-extern crate core_foundation;
-
-#[cfg(test)]
 mod tests;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -7,19 +7,10 @@ pub trait NativeGLContextMethods {
     fn create_headless() -> Result<Self, &'static str>;
     fn is_current(&self) -> bool;
     fn make_current(&self) -> Result<(), &'static str>;
+    fn unbind(&self) -> Result<(), &'static str>;
 
     #[cfg(feature="texture_surface")]
     fn get_metadata(&self) -> NativeGraphicsMetadata;
-
-    #[cfg(target_os="android")]
-    fn is_gles() -> bool {
-        true
-    }
-
-    #[cfg(not(target_os="android"))]
-    fn is_gles() -> bool {
-        false
-    }
 }
 
 #[cfg(target_os="linux")]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -22,7 +22,6 @@ extern {}
 // This is probably a time bomb
 static mut GL_LOADED : bool = false;
 
-
 fn load_gl() {
     unsafe {
         if GL_LOADED {


### PR DESCRIPTION
This adds missing destructor for `NativeGLContext` on EGL, and makes
destructors on other platforms work better unbinding the context first.
