### PR TITLE
Update to latest rust-layers

### DIFF
--- a/src/draw_buffer.rs
+++ b/src/draw_buffer.rs
@@ -266,7 +266,7 @@ impl DrawBufferHelpers for DrawBuffer {
                 let mut texture = Texture::new(target, Size2D::new(self.size.width as usize, self.size.height as usize));
                 texture.flip = flip;
 
-                let surface_wrapper = LayersSurfaceWrapper::new(context.get_metadata(), self.size, self.size.width * (if attrs.alpha { 4 } else { 3 }));
+                let surface_wrapper = LayersSurfaceWrapper::new(context.get_metadata(), self.size);
                 surface_wrapper.bind_to_texture(&texture);
 
                 Some(ColorAttachment::TextureWithSurface(surface_wrapper, texture))

--- a/src/layers_surface_wrapper.rs
+++ b/src/layers_surface_wrapper.rs
@@ -29,13 +29,12 @@ fn create_compositing_context(_: &NativeGraphicsMetadata) -> NativeCompositingGr
 }
 
 impl LayersSurfaceWrapper {
-    pub fn new(metadata: NativeGraphicsMetadata, size: Size2D<i32>, stride: i32) -> LayersSurfaceWrapper {
+    pub fn new(metadata: NativeGraphicsMetadata, size: Size2D<i32>) -> LayersSurfaceWrapper {
         let graphics_ctx = NativePaintingGraphicsContext::from_metadata(&metadata);
 
         let compositing_ctx = create_compositing_context(&metadata);
 
-        // TODO(ecoal95): Check if size.width is the stride we must use
-        let mut surf = NativeSurface::new(&graphics_ctx, size, stride);
+        let mut surf = NativeSurface::new(&graphics_ctx, size);
         surf.mark_will_leak();
 
         LayersSurfaceWrapper {


### PR DESCRIPTION
The stride option is no longer required when creating a NativeSurface.
