### PR TITLE
Allow serialization of WebGL context attributes via `serde`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ libc = "*"
 log  = "*"
 gleam = "0.1"
 euclid = "0.1"
+serde = "*"
+serde_macros = "*"
 
 [dependencies.layers]
 git = "https://github.com/servo/rust-layers"

--- a/src/gl_context_attributes.rs
+++ b/src/gl_context_attributes.rs
@@ -1,7 +1,7 @@
 
 /// This structure represents the attributes the context must support
 /// It's almost (if not) identical to WebGLGLContextAttributes
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, Deserialize, Serialize)]
 pub struct GLContextAttributes {
     pub alpha: bool,
     pub depth: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,11 @@
+#![feature(custom_derive)]
+#![feature(plugin)]
+#![plugin(serde_macros)]
+
 extern crate gleam;
 extern crate libc;
 extern crate euclid;
+extern crate serde;
 
 #[cfg(target_os="linux")]
 extern crate x11;


### PR DESCRIPTION
This will allow us to perform the multiprocess split.

r? @glennw
