### PR TITLE
Native surfaces now store their size

### DIFF
--- a/src/layers_surface_wrapper.rs
+++ b/src/layers_surface_wrapper.rs
@@ -11,7 +11,6 @@ use euclid::Size2D;
 pub struct LayersSurfaceWrapper {
     display: NativeDisplay,
     surface: NativeSurface,
-    size: Size2D<i32>,
 }
 
 impl LayersSurfaceWrapper {
@@ -22,13 +21,11 @@ impl LayersSurfaceWrapper {
         LayersSurfaceWrapper {
             display: display,
             surface: surf,
-            size: size,
         }
     }
 
     pub fn bind_to_texture(&self, texture: &Texture) {
-        let size = Size2D::new(self.size.width as isize, self.size.height as isize);
-        self.surface.bind_to_texture(&self.display, texture, size)
+        self.surface.bind_to_texture(&self.display, texture)
     }
 
     pub fn borrow_surface(&self) -> &NativeSurface {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -102,7 +102,7 @@ fn test_texture_surface_color_attachment() {
 
     let compositing_context = get_compositing_context(&ctx);
 
-    surface.bind_to_texture(&compositing_context, &texture, Size2D::new(size.width as isize, size.height as isize));
+    surface.bind_to_texture(&compositing_context, &texture);
 
     // Bind the texture, get its pixels in rgba format and test
     // if it has the surface contents


### PR DESCRIPTION
We no longer have to pass size as an argument to some methods.
