### PR TITLE
Fix nightly warnings related to lifetimes

### DIFF
--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(feature="texture_surface")]
 use layers::platform::surface::NativeDisplay;
 
-pub trait NativeGLContextMethods {
+pub trait NativeGLContextMethods: Sized {
     fn get_proc_address(&str) -> *const ();
 
     fn create_headless() -> Result<Self, &'static str>;


### PR DESCRIPTION
The following warnings appear:

```
src/platform/mod.rs:7:5: 7:56 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/platform/mod.rs:7     fn create_headless() -> Result<Self, &'static str>;
                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/platform/mod.rs:7:5: 7:56 help: run `rustc --explain E0277` to see a detailed explanation
src/platform/mod.rs:7:5: 7:56 note: `Self` does not have a constant size known at compile-time
src/platform/mod.rs:7     fn create_headless() -> Result<Self, &'static str>;
                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/platform/mod.rs:7:5: 7:56 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/platform/mod.rs:7     fn create_headless() -> Result<Self, &'static str>;
                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/platform/mod.rs:7:5: 7:56 note: required by `core::result::Result`
src/platform/mod.rs:7     fn create_headless() -> Result<Self, &'static str>;
                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

...because of:

https://github.com/rust-lang/rfcs/pull/1214
