### PR TITLE
Add glutin-based platform, use it on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+*~

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,6 @@ features = ["xlib"]
 [target.aarch64-unknown-linux-gnu.dependencies.x11]
 version = "^2.0.1"
 features = ["xlib"]
+
+[target.x86_64-pc-windows-gnu.dependencies]
+glutin = "*"

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -40,3 +40,8 @@ pub use self::with_egl::NativeGLContext;
 // #[cfg(not(target_os="linux"))]
 // pub use platform::with_egl::NativeGLContext;
 
+#[cfg(target_os="windows")]
+pub mod with_glutin;
+
+#[cfg(target_os="windows")]
+pub use self::with_glutin::NativeGLContext;

--- a/src/platform/with_glutin/mod.rs
+++ b/src/platform/with_glutin/mod.rs
@@ -1,0 +1,51 @@
+extern crate glutin;
+
+use platform::NativeGLContextMethods;
+#[cfg(feature="texture_surface")]
+use layers::platform::surface::NativeDisplay;
+
+#[cfg(not(feature="texture_surface"))]
+struct NativeDisplay;
+
+pub struct NativeGLContext {
+    context: glutin::HeadlessContext,
+    display: NativeDisplay,
+}
+
+impl NativeGLContextMethods for NativeGLContext {
+    fn get_proc_address(addr: &str) -> *const () {
+        unsafe {
+            0 as *const ()
+        }
+    }
+
+    fn create_headless() -> Result<Self, &'static str> {
+        let display = NativeDisplay;
+        return Ok(NativeGLContext {
+            context: glutin::HeadlessRendererBuilder::new(128, 128).build().unwrap(),
+            display: display,
+        });
+    }
+
+    fn is_current(&self) -> bool {
+        return self.context.is_current();
+    }
+
+    fn make_current(&self) -> Result<(), &'static str> {
+        unsafe {
+            match self.context.make_current() {
+                Ok(()) => Ok(()),
+                Err(_) => Err("MakeCurrent failed")
+            }
+        }
+    }
+
+    fn unbind(&self) -> Result<(), &'static str> {
+        Ok(())
+    }
+
+    #[cfg(feature="texture_surface")]
+    fn get_display(&self) -> NativeDisplay {
+        self.display
+    }
+}


### PR DESCRIPTION
This commit adds a windows backend, using glutin to provide context creation and related stuff to avoid having to implement WGL context creation a second time in here.
