### PR TITLE
Allow failure on glutin platform and minor nits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ script:
   - cargo build --features texture_surface --verbose
   # FIXME(ecoal95): Travis' ubuntu doesn't have the neccessary graphics stack and it fails
   - if [ "$TRAVIS_OS_NAME" != "linux" ]; then cargo test --verbose; fi
+  - if [ "$TRAVIS_OS_NAME" != "linux" ]; then cargo test --features texture_surface --verbose; fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,5 +46,7 @@ features = ["xlib"]
 version = "^2.0.1"
 features = ["xlib"]
 
-[target.x86_64-pc-windows-gnu.dependencies]
-glutin = "*"
+[target.x86_64-pc-windows-gnu.dependencies.glutin]
+git = "https://github.com/servo/glutin"
+branch = "servo"
+

--- a/src/draw_buffer.rs
+++ b/src/draw_buffer.rs
@@ -262,12 +262,16 @@ impl DrawBufferHelpers for DrawBuffer {
             #[cfg(feature="texture_surface")]
             ColorAttachmentType::TextureWithSurface => {
                 // TODO(ecoal95): check if this is correct
-                let (flip, target) = Texture::texture_flip_and_target(true);
+                let (flip, target) = Texture::texture_flip_and_target(false);
                 let mut texture = Texture::new(target, Size2D::new(self.size.width as usize, self.size.height as usize));
                 texture.flip = flip;
 
                 let surface_wrapper = LayersSurfaceWrapper::new(context.get_display(), self.size);
                 surface_wrapper.bind_to_texture(&texture);
+
+                unsafe {
+                    debug_assert!(gl::GetError() == gl::NO_ERROR);
+                }
 
                 Some(ColorAttachment::TextureWithSurface(surface_wrapper, texture))
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ extern crate x11;
 extern crate cgl;
 #[cfg(target_os="macos")]
 extern crate core_foundation;
+#[cfg(target_os="windows")]
+extern crate glutin;
 
 mod platform;
 pub use platform::{NativeGLContext, NativeGLContextMethods};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub use gl_formats::GLFormats;
 extern crate log;
 
 #[cfg(target_os="linux")]
+#[allow(improper_ctypes)]
 mod glx {
     include!(concat!(env!("OUT_DIR"), "/glx_bindings.rs"));
 }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -31,15 +31,6 @@ pub mod with_egl;
 #[cfg(target_os="android")]
 pub use self::with_egl::NativeGLContext;
 
-// TODO(ecoal95): Get a machine to test with mac and
-// get android building:
-//
-// #[cfg(not(target_os="linux"))]
-// pub mod with_egl;
-//
-// #[cfg(not(target_os="linux"))]
-// pub use platform::with_egl::NativeGLContext;
-
 #[cfg(target_os="windows")]
 pub mod with_glutin;
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -36,3 +36,9 @@ pub mod with_glutin;
 
 #[cfg(target_os="windows")]
 pub use self::with_glutin::NativeGLContext;
+
+#[cfg(not(any(target_os="linux", target_os="macos", target_os="android", target_os="windows")))]
+pub mod not_implemented;
+
+#[cfg(not(any(target_os="linux", target_os="macos", target_os="android", target_os="windows")))]
+pub use self::not_implemented::NativeGLContext;

--- a/src/platform/not_implemented/native_gl_context.rs
+++ b/src/platform/not_implemented/native_gl_context.rs
@@ -6,7 +6,7 @@ pub struct NativeGLContext;
 use layers::platform::surface::NativeGraphicsMetadata;
 
 impl NativeGLContextMethods for NativeGLContext {
-    fn get_proc_address(addr: &str) -> *const () {
+    fn get_proc_address(_addr: &str) -> *const () {
         0 as *const ()
     }
 
@@ -20,6 +20,10 @@ impl NativeGLContextMethods for NativeGLContext {
 
     fn make_current(&self) -> Result<(), &'static str> {
         Err("Not implemented (yet)")
+    }
+
+    fn unbind(&self) -> Result<(), &'static str> {
+        unimplemented!()
     }
 
     #[cfg(feature="texture_surface")]


### PR DESCRIPTION
We should probably change `Err(&str)` to another type of error...
