### PR TITLE
Fix use of glXChooseFBConfig.

### DIFF
--- a/src/platform/with_glx/utils.rs
+++ b/src/platform/with_glx/utils.rs
@@ -60,7 +60,7 @@ pub fn create_offscreen_pixmap_backed_context(size: Size2D<i32>) -> Result<Nativ
     let mut attributes = [
         glx::DRAWABLE_TYPE as c_int, glx::PIXMAP_BIT as c_int,
         glx::X_RENDERABLE as c_int, 1,
-        glx::NONE as c_int
+        0 as c_int
     ];
 
     let mut config_count : c_int = 0;


### PR DESCRIPTION
Based on https://www.opengl.org/sdk/docs/man2/xhtml/glXChooseFBConfig.xml
the last parameter of the attributes array must be None (which == 0).

Confusingly, this is different from GLX_NONE, which is non-zero.

This fixes webgl context creation on some drivers, in particular nVidia proprietary drivers but probably others too.
