### PR TITLE
platform/egl: Fix EGL texture implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,7 @@ os:
 
 script:
   - cargo build --verbose
+  # We cannot test egl nor glx in Travis' linux
+  # - cargo test --verbose
+  # - cargo test --verbose --features test_egl_in_linux
   - if [ "$TRAVIS_OS_NAME" != "linux" ]; then cargo test --verbose; fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ build = "build.rs"
 gl_generator = "0.4"
 khronos_api = "1.0"
 
+# NOTE: Just for testing use, there are no other changes
+[features]
+default = []
+test_egl_in_linux = []
+
 [dependencies]
 log  = "0.3.3"
 gleam = "0.2"

--- a/src/draw_buffer.rs
+++ b/src/draw_buffer.rs
@@ -200,7 +200,6 @@ impl DrawBufferHelpers for DrawBuffer {
 
                 // TODO(ecoal95): Check gleam safe wrappers for these functions
                 unsafe {
-                    gl::Enable(gl::TEXTURE_2D);
                     gl::GenTextures(1, &mut texture);
                     debug_assert!(texture != 0);
 


### PR DESCRIPTION
The EGL test failures where provoked by two things:
- GLES 2.0 deprecates `gl::TEXTURE_2D` as a valid parameter to
  `gl::enable`, which was provoking an unexpected INVALID_ENUM error.
- GLES 2.0 doesn't have `glGetTexImage`, so to test that writing to a
  texture actually works we have to bind it to another FBO. We do it on
  the sharing test.

Also, added a no-op feature to easily run egl tests on linux. Too bad we can't test it on Travis :(
