### PR TITLE
Use serde serialization as a standalone feature and publish on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "offscreen_gl_context"
 license = "MIT / Apache-2.0"
 version = "0.1.0"
 authors = ["ecoal95 <ecoal95@gmail.com>", "The Servo Project Developers"]
-description = "Creation and manipulation of HW accelerated offscreen rendering contexts in multiple platforms. Originally intended for the Servo project WebGL implementation."
+description = "Creation and manipulation of HW accelerated offscreen rendering contexts in multiple platforms. Originally intended for the Servo project's WebGL implementation."
 repository = "https://github.com/ecoal95/rust-offscreen-rendering-context"
 build = "build.rs"
 
@@ -15,13 +15,14 @@ khronos_api = "1.0"
 [features]
 default = []
 test_egl_in_linux = []
+serde_serialization = ["serde", "serde_macros"]
 
 [dependencies]
 log  = "0.3.3"
 gleam = "0.2"
 euclid = "0.6.1"
-serde = ">=0.6.1, <0.8"
-serde_macros = ">=0.6.1, <0.8"
+serde = { version = ">=0.6.1, <0.8", optional = true }
+serde_macros = { version = ">=0.6.1, <0.8", optional = true }
 
 [target.x86_64-apple-darwin.dependencies]
 core-foundation = "0.2.0"

--- a/src/gl_context_attributes.rs
+++ b/src/gl_context_attributes.rs
@@ -1,7 +1,8 @@
 
 /// This structure represents the attributes the context must support
 /// It's almost (if not) identical to WebGLGLContextAttributes
-#[derive(Clone, Debug, Copy, Deserialize, Serialize)]
+#[derive(Clone, Debug, Copy)]
+#[cfg_attr(feature="serde_serialization", derive(Serialize, Deserialize))]
 pub struct GLContextAttributes {
     pub alpha: bool,
     pub depth: bool,

--- a/src/gl_limits.rs
+++ b/src/gl_limits.rs
@@ -1,7 +1,8 @@
 use gleam::gl::types::GLint;
 use gleam::gl;
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone)]
+#[cfg_attr(feature="serde_serialization", derive(Serialize, Deserialize))]
 pub struct GLLimits {
     pub max_vertex_attribs: GLint,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,10 @@
-#![feature(custom_derive)]
-#![feature(plugin)]
-#![plugin(serde_macros)]
+#![cfg_attr(feature="serde_serialization", feature(plugin, custom_derive))]
+#![cfg_attr(feature="serde_serialization", plugin(serde_macros))]
 
 extern crate gleam;
 extern crate euclid;
+
+#[cfg(feature="serde_serialization")]
 extern crate serde;
 
 #[cfg(target_os="linux")]


### PR DESCRIPTION
This will prevent random build breaking due to two derives.
