### PR TITLE
Add max texture size members to GLLimits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "offscreen_gl_context"
 license = "MIT / Apache-2.0"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["ecoal95 <ecoal95@gmail.com>", "The Servo Project Developers"]
 description = "Creation and manipulation of HW accelerated offscreen rendering contexts in multiple platforms. Originally intended for the Servo project's WebGL implementation."
 repository = "https://github.com/ecoal95/rust-offscreen-rendering-context"

--- a/src/gl_limits.rs
+++ b/src/gl_limits.rs
@@ -4,12 +4,16 @@ use gleam::gl;
 #[cfg_attr(feature="serde_serialization", derive(Serialize, Deserialize))]
 pub struct GLLimits {
     pub max_vertex_attribs: u32,
+    pub max_tex_size: u32,
+    pub max_cube_map_tex_size: u32
 }
 
 impl GLLimits {
     pub fn detect() -> GLLimits {
         GLLimits {
             max_vertex_attribs: gl::get_integer_v(gl::MAX_VERTEX_ATTRIBS) as u32,
+            max_tex_size: gl::get_integer_v(gl::MAX_TEXTURE_SIZE) as u32,
+            max_cube_map_tex_size: gl::get_integer_v(gl::MAX_CUBE_MAP_TEXTURE_SIZE) as u32
         }
     }
 }


### PR DESCRIPTION
As discussed on IRC. Add `max_tex_size` and `max_cube_map_size` to GLLimits. I'll then switch on `target` to select the appropriate max.

Let me know if this is not what you had in mind.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/emilio/rust-offscreen-rendering-context/55)

<!-- Reviewable:end -->
