### PR TITLE
Clamp the drawbuffer size to a minnimum, add more tests, and cleanups.

### DIFF
--- a/src/draw_buffer.rs
+++ b/src/draw_buffer.rs
@@ -7,13 +7,14 @@ use NativeGLContextMethods;
 
 use std::ptr;
 
+#[derive(Debug)]
 pub enum ColorAttachmentType {
     Texture,
     Renderbuffer,
 }
 
-impl ColorAttachmentType {
-    pub fn default() -> ColorAttachmentType {
+impl Default for ColorAttachmentType {
+    fn default() -> ColorAttachmentType {
         ColorAttachmentType::Renderbuffer
     }
 }
@@ -23,6 +24,7 @@ impl ColorAttachmentType {
 /// Or a surface bound to a texture
 /// bound to a framebuffer as a color
 /// attachment
+#[derive(Debug)]
 pub enum ColorAttachment {
     Renderbuffer(GLuint),
     Texture(GLuint),
@@ -83,7 +85,7 @@ impl DrawBuffer {
                                           size: Size2D<i32>,
                                           color_attachment_type: ColorAttachmentType)
         -> Result<DrawBuffer, &'static str> {
-
+        debug!("Creating draw buffer {:?}, {:?}", size, color_attachment_type);
         let attrs = context.borrow_attributes();
         let capabilities = context.borrow_capabilities();
 
@@ -215,6 +217,8 @@ impl DrawBufferHelpers for DrawBuffer {
                     gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_WRAP_S, gl::CLAMP_TO_EDGE as GLint);
                     gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_WRAP_T, gl::CLAMP_TO_EDGE as GLint);
 
+                    debug_assert!(gl::get_error() == gl::NO_ERROR);
+
                     Some(ColorAttachment::Texture(texture))
                 }
             },
@@ -246,15 +250,15 @@ impl DrawBufferHelpers for DrawBuffer {
             // NOTE: The assertion fails if the framebuffer is not bound
             debug_assert!(gl::IsFramebuffer(self.framebuffer) == gl::TRUE);
 
-            match self.color_attachment.as_ref().unwrap() {
-                &ColorAttachment::Renderbuffer(color_renderbuffer) => {
+            match *self.color_attachment.as_ref().unwrap() {
+                ColorAttachment::Renderbuffer(color_renderbuffer) => {
                     gl::FramebufferRenderbuffer(gl::FRAMEBUFFER,
                                                 gl::COLOR_ATTACHMENT0,
                                                 gl::RENDERBUFFER,
                                                 color_renderbuffer);
                     debug_assert!(gl::IsRenderbuffer(color_renderbuffer) == gl::TRUE);
                 },
-                &ColorAttachment::Texture(texture_id) => {
+                ColorAttachment::Texture(texture_id) => {
                     gl::FramebufferTexture2D(gl::FRAMEBUFFER,
                                              gl::COLOR_ATTACHMENT0,
                                              gl::TEXTURE_2D,

--- a/src/gl_context.rs
+++ b/src/gl_context.rs
@@ -100,7 +100,6 @@ impl<Native> GLContext<Native>
         self.native_context.handle()
     }
 
-
     // Allow borrowing these unmutably
     pub fn borrow_attributes(&self) -> &GLContextAttributes {
         &self.attributes
@@ -142,7 +141,8 @@ impl<Native> GLContext<Native>
     // in order to keep this generic
     pub fn resize(&mut self, size: Size2D<i32>) -> Result<(), &'static str> {
         if self.draw_buffer.is_some() {
-            let color_attachment_type = self.borrow_draw_buffer().unwrap().color_attachment_type();
+            let color_attachment_type =
+                self.borrow_draw_buffer().unwrap().color_attachment_type();
             self.create_draw_buffer(size, color_attachment_type)
         } else {
             Err("No DrawBuffer found")

--- a/src/gl_context_attributes.rs
+++ b/src/gl_context_attributes.rs
@@ -54,11 +54,13 @@ impl GLContextAttributes {
             preserve_drawing_buffer: false,
         }
     }
+}
 
+impl Default for GLContextAttributes {
     // FIXME(ecoal95): `antialias` should be true by default
     //   but we do not support antialising so... We must change it
     //   when we do. See GLFeature.
-    pub fn default() -> GLContextAttributes {
+    fn default() -> GLContextAttributes {
         GLContextAttributes {
             alpha: true,
             depth: true,
@@ -69,5 +71,3 @@ impl GLContextAttributes {
         }
     }
 }
-
-

--- a/src/gl_context_capabilities.rs
+++ b/src/gl_context_capabilities.rs
@@ -8,7 +8,7 @@ use GLFeature;
 /// should have under the field `capabilities`, as a public field
 /// This should allow us to know the capabilities of a given
 /// GLContext without repeating the same code over and over
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct GLContextCapabilities {
     // max antialising samples, 0 if no antialising supported
     pub max_samples: GLint,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -257,3 +257,13 @@ fn test_in_a_row() {
                                       ColorAttachmentType::Texture,
                                       Some(&handle)).unwrap();
 }
+
+#[test]
+fn test_zero_size() {
+    load_gl();
+
+    GLContext::<NativeGLContext>::new(Size2D::new(0, 320),
+                                      GLContextAttributes::default(),
+                                      ColorAttachmentType::Texture,
+                                      None).unwrap();
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -171,3 +171,89 @@ fn test_limits() {
                                                     None).unwrap();
     assert!(context.borrow_limits().max_vertex_attribs != 0);
 }
+
+#[test]
+fn test_no_alpha() {
+    load_gl();
+    let mut attributes = GLContextAttributes::default();
+    attributes.alpha = false;
+
+    let size = Size2D::new(256, 256);
+    let context = GLContext::<NativeGLContext>::new(size,
+                                                    attributes,
+                                                    ColorAttachmentType::Texture,
+                                                    None).unwrap();
+    assert!(context.borrow_limits().max_vertex_attribs != 0);
+}
+
+#[test]
+fn test_no_depth() {
+    load_gl();
+    let mut attributes = GLContextAttributes::default();
+    attributes.depth = false;
+
+    let size = Size2D::new(256, 256);
+    let context = GLContext::<NativeGLContext>::new(size,
+                                                    attributes,
+                                                    ColorAttachmentType::Texture,
+                                                    None).unwrap();
+    assert!(context.borrow_limits().max_vertex_attribs != 0);
+}
+
+#[test]
+fn test_no_depth_no_alpha() {
+    load_gl();
+    let mut attributes = GLContextAttributes::default();
+    attributes.depth = false;
+    attributes.alpha = false;
+
+    let size = Size2D::new(256, 256);
+    let context = GLContext::<NativeGLContext>::new(size,
+                                                    attributes,
+                                                    ColorAttachmentType::Texture,
+                                                    None).unwrap();
+    assert!(context.borrow_limits().max_vertex_attribs != 0);
+}
+
+#[test]
+fn test_no_premul_alpha() {
+    load_gl();
+    let mut attributes = GLContextAttributes::default();
+    attributes.depth = false;
+    attributes.alpha = false;
+    attributes.premultiplied_alpha = false;
+
+    let size = Size2D::new(256, 256);
+    let context = GLContext::<NativeGLContext>::new(size,
+                                                    attributes,
+                                                    ColorAttachmentType::Texture,
+                                                    None).unwrap();
+    assert!(context.borrow_limits().max_vertex_attribs != 0);
+}
+
+#[test]
+fn test_in_a_row() {
+    load_gl();
+    let mut attributes = GLContextAttributes::default();
+    attributes.depth = false;
+    attributes.alpha = false;
+    attributes.premultiplied_alpha = false;
+
+    let size = Size2D::new(256, 256);
+    let context = GLContext::<NativeGLContext>::new(size,
+                                                    attributes.clone(),
+                                                    ColorAttachmentType::Texture,
+                                                    None).unwrap();
+
+    let handle = context.handle();
+
+    GLContext::<NativeGLContext>::new(size,
+                                      attributes.clone(),
+                                      ColorAttachmentType::Texture,
+                                      Some(&handle)).unwrap();
+
+    GLContext::<NativeGLContext>::new(size,
+                                      attributes.clone(),
+                                      ColorAttachmentType::Texture,
+                                      Some(&handle)).unwrap();
+}


### PR DESCRIPTION
The tests in the first round were unsuccessful attempts to reproduce https://github.com/servo/servo/issues/12320.

The second commit fixes that.

r? @jdm 
