### PR TITLE
Unset the texture/rb bindings after we use them.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ build = "build.rs"
 
 [build-dependencies]
 gl_generator = "0.5"
-khronos_api = "1.0"
 
 # NOTE: Just for testing use, there are no other changes
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "offscreen_gl_context"
 license = "MIT / Apache-2.0"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Emilio Cobos Álvarez <ecoal95@gmail.com>", "The Servo Project Developers"]
 description = "Creation and manipulation of HW accelerated offscreen rendering contexts in multiple platforms. Originally intended for the Servo project's WebGL implementation."
 repository = "https://github.com/emilio/rust-offscreen-rendering-context"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,4 @@
 extern crate gl_generator;
-extern crate khronos_api;
 
 use std::env;
 use std::fs::File;

--- a/src/draw_buffer.rs
+++ b/src/draw_buffer.rs
@@ -75,6 +75,7 @@ fn create_renderbuffer(format: GLenum,
         gl::GenRenderbuffers(1, &mut ret);
         gl::BindRenderbuffer(gl::RENDERBUFFER, ret);
         gl::RenderbufferStorage(gl::RENDERBUFFER, format, size.width, size.height);
+        gl::BindRenderbuffer(gl::RENDERBUFFER, 0);
     }
 
     ret
@@ -226,6 +227,8 @@ impl DrawBufferHelpers for DrawBuffer {
                     // TODO(ecoal95): Check if these two are neccessary, probably not
                     gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_WRAP_S, gl::CLAMP_TO_EDGE as GLint);
                     gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_WRAP_T, gl::CLAMP_TO_EDGE as GLint);
+
+                    gl::BindTexture(gl::TEXTURE_2D, 0);
 
                     debug_assert!(gl::get_error() == gl::NO_ERROR);
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,4 @@
 use gleam::gl;
-use gleam::gl::types::GLint;
 use euclid::Size2D;
 use std::sync::{Once, ONCE_INIT};
 
@@ -132,10 +131,6 @@ fn test_sharing() {
 
     primary.make_current().unwrap();
     assert!(unsafe { gl::IsTexture(secondary_texture_id) != 0 });
-
-    // Ensure the old texture is bound, and bind the new one
-    assert!(gl::get_integer_v(gl::TEXTURE_BINDING_2D) == primary_texture_id as GLint);
-
 
     // Clearing and re-binding to a framebuffer instead of using getTexImage since it's not
     // available in GLES2


### PR DESCRIPTION
Fixes webgl conformance's default-texture.html.
