### PR TITLE
Add GLDispatcher traits to allow send GL commands to the thread of the shared context

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub use platform::{NativeGLContext, NativeGLContextMethods, NativeGLContextHandl
 pub use platform::{OSMesaContext, OSMesaContextHandle};
 
 mod gl_context;
-pub use gl_context::GLContext;
+pub use gl_context::{GLContext, GLContextDispatcher};
 
 mod draw_buffer;
 pub use draw_buffer::{DrawBuffer, ColorAttachmentType};

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,3 +1,5 @@
+use gl_context::GLContextDispatcher;
+
 pub trait NativeGLContextMethods: Sized {
     type Handle;
 
@@ -8,6 +10,11 @@ pub trait NativeGLContextMethods: Sized {
     fn current_handle() -> Option<Self::Handle>;
 
     fn create_shared(with: Option<&Self::Handle>) -> Result<Self, &'static str>;
+
+    fn create_shared_with_dispatcher(with: Option<&Self::Handle>, _dispatcher: Option<Box<GLContextDispatcher>>)
+        -> Result<Self, &'static str> {
+        Self::create_shared(with)
+    }
 
     fn create_headless() -> Result<Self, &'static str> {
         Self::create_shared(None)

--- a/src/platform/with_wgl/native_gl_context.rs
+++ b/src/platform/with_wgl/native_gl_context.rs
@@ -1,7 +1,9 @@
 use platform::NativeGLContextMethods;
+use gl_context::GLContextDispatcher;
 use std::ffi::CString;
 use std::os::raw::c_void;
 use std::ptr;
+use std::sync::mpsc;
 
 use winapi;
 use user32;
@@ -108,10 +110,34 @@ impl NativeGLContextMethods for NativeGLContext {
     }
 
     fn create_shared(with: Option<&Self::Handle>) -> Result<NativeGLContext, &'static str> {
-        let render_ctx = match with {
-            Some(ref handle) => handle.0,
-            None => ptr::null_mut(),
+        Self::create_shared_with_dispatcher(with, None)
+    }
+
+    fn create_shared_with_dispatcher(with: Option<&Self::Handle>, dispatcher: Option<Box<GLContextDispatcher>>)
+        -> Result<NativeGLContext, &'static str> {
+        let (render_ctx, device_ctx) = match with {
+            Some(ref handle) => (handle.0, handle.1),
+            None => (ptr::null_mut(), ptr::null_mut())
         };
+
+        if let Some(ref dispatcher) = dispatcher {
+            // wglShareLists fails if the context to share is current in a different thread.
+            // Additionally wglMakeCurrent cannot 'steal' a context that is current in other thread, so
+            // we have to unbind the shared context in its own thread, call wglShareLists in this thread
+            // and bind the original share context again when the wglShareList is completed.
+            let (tx, rx) = mpsc::channel();
+            dispatcher.dispatch(Box::new(move || {
+                unsafe {
+                    if wgl::MakeCurrent(ptr::null_mut(), ptr::null_mut()) == 0 {
+                        error!("WGL MakeCurrent failed");
+                    }
+                }
+                tx.send(()).unwrap();
+            }));
+            // Wait until wglMakeCurrent operation is completed in the thread of the shared context
+            rx.recv().unwrap();
+        }
+
         match unsafe { utils::create_offscreen(render_ctx, &WGLAttributes::default()) } {
             Ok(ref res) => {
                 let ctx = NativeGLContext {
@@ -119,6 +145,23 @@ impl NativeGLContextMethods for NativeGLContext {
                     device_ctx: res.1,
                     weak: false,
                 };
+
+                // Restore shared context
+                if let Some(ref dispatcher) = dispatcher {
+                    let (tx, rx) = mpsc::channel();
+                    let handle = NativeGLContextHandle(render_ctx, device_ctx);
+                    dispatcher.dispatch(Box::new(move || {
+                        unsafe { 
+                            if wgl::MakeCurrent(handle.1 as *const _, handle.0 as *const _) == 0 {
+                                error!("WGL MakeCurrent failed!");
+                            } 
+                        };
+                        tx.send(()).unwrap();
+                    }));
+                    // Wait until wglMakeCurrent operation is completed in the thread of the shared context
+                    rx.recv().unwrap();
+                }
+
                 Ok(ctx)
             }
             Err(s) => {


### PR DESCRIPTION
To make the WGL implementation fully compatible with shared GL contexts in multiple threads (the case of servo & webrender ;)) we need to dispatch some gl commands to a specific thread. The wglShareLists function fails if the context to share is current in a different thread. Additionally wglMakeCurrent cannot 'steal' a context that is current in other thread, so we have to unbind the shared context in its own thread, call wglShareLists in the thread of the new context and bind the original share context again when the wglShareList is completed.

Currently when we receive a shared handle we don't know in which thread is bound and running. Even if we knew we couldn't dispatch commands to that thread because the users of the library are responsible for handling the thread event queues and we want to keep this library generic and atomic.

To fix this problem I have added a GLDispatcher traits type. Now the caller can (optionally) include a dispatcher when creating a NativeContext. The API is still backwards compatbile because the previous contructors still work.

I have already tested some webgl animations in WGL running on servo with webrender enabled. The context sharing is working ok now with this approach.

I'll push the updated WGL branch and a PR to webrender/servo when this is merged.
