### PR TITLE
Fix CGL multithreading error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,4 +38,6 @@ winapi = "0.2"
 gdi32-sys = "0.2"
 user32-sys = "0.2"
 kernel32-sys = "0.2"
+
+[target.'cfg(any(target_os="macos", target_os="windows"))'.dependencies]
 lazy_static = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ extern crate kernel32;
 extern crate gdi32;
 #[cfg(target_os = "windows")]
 extern crate user32;
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os="macos", target_os="windows"))]
 #[macro_use]
 extern crate lazy_static;
 


### PR DESCRIPTION
Multithreading tests fail with Err("CGLChoosePixelFormat") error  on a MacBook with a clean macOS sierra install. 

It seems that CGLChoosePixelFormat can fail if multiple threads try to open a display connection simultaneously. Fixed the issue adding a static mutex guard.
