### PR TITLE
Drop EGL depedency unless needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "offscreen_gl_context"
 license = "MIT / Apache-2.0"
-version = "0.4.5"
+version = "0.5.0"
 authors = ["Emilio Cobos Álvarez <ecoal95@gmail.com>", "The Servo Project Developers"]
 description = "Creation and manipulation of HW accelerated offscreen rendering contexts in multiple platforms. Originally intended for the Servo project's WebGL implementation."
 repository = "https://github.com/emilio/rust-offscreen-rendering-context"

--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,7 @@ fn main() {
             .write_bindings(gl_generator::StaticGenerator, &mut file).unwrap();
     }
 
-    if target.contains("android") || target.contains("linux") {
+    if target.contains("android") || (target.contains("linux") && cfg!(feature = "test_egl_in_linux")) {
         let mut file = File::create(&dest.join("egl_bindings.rs")).unwrap();
         Registry::new(Api::Egl, (1, 4), Profile::Core, Fallbacks::All, [])
             .write_bindings(gl_generator::StaticGenerator, &mut file).unwrap();

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -36,7 +36,7 @@ pub mod with_osmesa;
 #[cfg(feature="osmesa")]
 pub use self::with_osmesa::{OSMesaContext, OSMesaContextHandle};
 
-#[cfg(any(target_os="android", target_os="linux"))]
+#[cfg(any(target_os="android", all(target_os="linux", feature = "test_egl_in_linux")))]
 pub mod with_egl;
 #[cfg(target_os="android")]
 pub use self::with_egl::{NativeGLContext, NativeGLContextHandle};


### PR DESCRIPTION
Right now when building webrender on Linux (with Gecko), this crate pulls in a libEGL dependency which is really not needed, as it's only required as part of a testing feature. This commit fixes that.