### PR TITLE
Clear draw buffer after creation and resize.

### DIFF
--- a/src/gl_context.rs
+++ b/src/gl_context.rs
@@ -158,7 +158,7 @@ impl<Native> GLContext<Native>
         if self.draw_buffer.is_some() {
             let color_attachment_type =
                 self.borrow_draw_buffer().unwrap().color_attachment_type();
-            self.create_draw_buffer(size, color_attachment_type)
+            self.init_offscreen(size, color_attachment_type)
         } else {
             Err("No DrawBuffer found")
         }
@@ -184,6 +184,8 @@ impl<T: NativeGLContextMethods> GLContextPrivateMethods for GLContext<T> {
         debug_assert!(self.is_current());
 
         unsafe {
+            gl::ClearColor(0.0, 0.0, 0.0, 0.0);
+            gl::Clear(gl::COLOR_BUFFER_BIT | gl::DEPTH_BUFFER_BIT | gl::STENCIL_BUFFER_BIT);
             gl::Scissor(0, 0, size.width, size.height);
             gl::Viewport(0, 0, size.width, size.height);
         }


### PR DESCRIPTION
I've been working on fixing the scissor test for https://github.com/servo/servo/pull/14075 and found that the GLContexts are not cleared after creation. That's why that test is failing now (after fixing what the spec says about scissor).

I'm adding the clear changes here because I think that clearing the created framebuffer is a good default for any project.  I had a lot of problems in the past with buggy Adreno GPUs on Android because of this. A initial clear is a safeguard to avoid problems. Some Adrenos were such bad that even required clearing the Depth/Stencil even if the buffer is neither created and used.