### PR TITLE
Remove gleam gl ffi usages from offscreen_gl_context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "offscreen_gl_context"
 license = "MIT / Apache-2.0"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Emilio Cobos Álvarez <ecoal95@gmail.com>", "The Servo Project Developers"]
 description = "Creation and manipulation of HW accelerated offscreen rendering contexts in multiple platforms. Originally intended for the Servo project's WebGL implementation."
 repository = "https://github.com/emilio/rust-offscreen-rendering-context"

--- a/src/draw_buffer.rs
+++ b/src/draw_buffer.rs
@@ -5,8 +5,6 @@ use gleam::gl::types::{GLuint, GLenum, GLint};
 use GLContext;
 use NativeGLContextMethods;
 
-use std::ptr;
-
 #[derive(Debug)]
 pub enum ColorAttachmentType {
     Texture,
@@ -41,11 +39,9 @@ impl ColorAttachment {
 
 impl Drop for ColorAttachment {
     fn drop(&mut self) {
-        unsafe {
-            match *self {
-                ColorAttachment::Renderbuffer(mut id) => gl::DeleteRenderbuffers(1, &mut id),
-                ColorAttachment::Texture(mut tex_id) => gl::DeleteTextures(1, &mut tex_id),
-            }
+        match *self {
+            ColorAttachment::Renderbuffer(id) => gl::delete_renderbuffers(&[id]),
+            ColorAttachment::Texture(tex_id) => gl::delete_textures(&[tex_id]),
         }
     }
 }
@@ -71,12 +67,10 @@ fn create_renderbuffer(format: GLenum,
                        size: &Size2D<i32>) -> GLuint {
     let mut ret: GLuint = 0;
 
-    unsafe {
-        gl::GenRenderbuffers(1, &mut ret);
-        gl::BindRenderbuffer(gl::RENDERBUFFER, ret);
-        gl::RenderbufferStorage(gl::RENDERBUFFER, format, size.width, size.height);
-        gl::BindRenderbuffer(gl::RENDERBUFFER, 0);
-    }
+    ret = gl::gen_renderbuffers(1)[0];
+    gl::bind_renderbuffer(gl::RENDERBUFFER, ret);
+    gl::renderbuffer_storage(gl::RENDERBUFFER, format, size.width, size.height);
+    gl::bind_renderbuffer(gl::RENDERBUFFER, 0);
 
     ret
 }
@@ -121,10 +115,8 @@ impl DrawBuffer {
 
         try!(draw_buffer.init(context, color_attachment_type));
 
-        unsafe {
-            debug_assert!(gl::CheckFramebufferStatus(gl::FRAMEBUFFER) == gl::FRAMEBUFFER_COMPLETE);
-            debug_assert!(gl::get_error() == gl::NO_ERROR);
-        }
+        debug_assert!(gl::check_frame_buffer_status(gl::FRAMEBUFFER) == gl::FRAMEBUFFER_COMPLETE);
+        debug_assert!(gl::get_error() == gl::NO_ERROR);
 
         Ok(draw_buffer)
     }
@@ -167,18 +159,11 @@ impl DrawBuffer {
 // parent with Rc<GLContext> and call make_current()
 impl Drop for DrawBuffer {
     fn drop(&mut self) {
-        unsafe {
-            gl::DeleteFramebuffers(1, &mut self.framebuffer);
+        gl::delete_framebuffers(&[self.framebuffer]);
 
-            // NOTE: Color renderbuffer is destroyed on drop of
-            //   ColorAttachment
-            let mut renderbuffers = [
-                self.stencil_renderbuffer,
-                self.depth_renderbuffer
-            ];
-
-            gl::DeleteRenderbuffers(2, renderbuffers.as_mut_ptr());
-        }
+        // NOTE: Color renderbuffer is destroyed on drop of
+        //   ColorAttachment
+        gl::delete_renderbuffers(&[self.stencil_renderbuffer, self.depth_renderbuffer]);
     }
 }
 
@@ -212,28 +197,26 @@ impl DrawBufferHelpers for DrawBuffer {
                 let mut texture = 0;
 
                 // TODO(ecoal95): Check gleam safe wrappers for these functions
-                unsafe {
-                    gl::GenTextures(1, &mut texture);
-                    debug_assert!(texture != 0);
+                texture = gl::gen_textures(1)[0];
+                debug_assert!(texture != 0);
 
-                    gl::BindTexture(gl::TEXTURE_2D, texture);
-                    gl::TexImage2D(gl::TEXTURE_2D, 0,
-                                   formats.texture_internal as GLint, self.size.width, self.size.height, 0, formats.texture, formats.texture_type, ptr::null_mut());
+                gl::bind_texture(gl::TEXTURE_2D, texture);
+                gl::tex_image_2d(gl::TEXTURE_2D, 0,
+                                 formats.texture_internal as GLint, self.size.width, self.size.height, 0, formats.texture, formats.texture_type, None);
 
-                    // Low filtering to allow rendering
-                    gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, gl::NEAREST as GLint);
-                    gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, gl::NEAREST as GLint);
+                // Low filtering to allow rendering
+                gl::tex_parameter_i(gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, gl::NEAREST as GLint);
+                gl::tex_parameter_i(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, gl::NEAREST as GLint);
 
-                    // TODO(ecoal95): Check if these two are neccessary, probably not
-                    gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_WRAP_S, gl::CLAMP_TO_EDGE as GLint);
-                    gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_WRAP_T, gl::CLAMP_TO_EDGE as GLint);
+                // TODO(ecoal95): Check if these two are neccessary, probably not
+                gl::tex_parameter_i(gl::TEXTURE_2D, gl::TEXTURE_WRAP_S, gl::CLAMP_TO_EDGE as GLint);
+                gl::tex_parameter_i(gl::TEXTURE_2D, gl::TEXTURE_WRAP_T, gl::CLAMP_TO_EDGE as GLint);
 
-                    gl::BindTexture(gl::TEXTURE_2D, 0);
+                gl::bind_texture(gl::TEXTURE_2D, 0);
 
-                    debug_assert!(gl::get_error() == gl::NO_ERROR);
+                debug_assert!(gl::get_error() == gl::NO_ERROR);
 
-                    Some(ColorAttachment::Texture(texture))
-                }
+                Some(ColorAttachment::Texture(texture))
             },
         };
 
@@ -248,52 +231,48 @@ impl DrawBufferHelpers for DrawBuffer {
             debug_assert!(self.stencil_renderbuffer != 0);
         }
 
-        unsafe {
-            gl::GenFramebuffers(1, &mut self.framebuffer);
-            debug_assert!(self.framebuffer != 0);
-        }
+        self.framebuffer = gl::gen_framebuffers(1)[0];
+        debug_assert!(self.framebuffer != 0);
 
         // Finally we attach them to the framebuffer
         self.attach_to_framebuffer()
     }
 
     fn attach_to_framebuffer(&mut self) -> Result<(), &'static str> {
-        unsafe {
-            gl::BindFramebuffer(gl::FRAMEBUFFER, self.framebuffer);
-            // NOTE: The assertion fails if the framebuffer is not bound
-            debug_assert!(gl::IsFramebuffer(self.framebuffer) == gl::TRUE);
+        gl::bind_framebuffer(gl::FRAMEBUFFER, self.framebuffer);
+        // NOTE: The assertion fails if the framebuffer is not bound
+        debug_assert!(gl::is_framebuffer(self.framebuffer) == gl::TRUE);
 
-            match *self.color_attachment.as_ref().unwrap() {
-                ColorAttachment::Renderbuffer(color_renderbuffer) => {
-                    gl::FramebufferRenderbuffer(gl::FRAMEBUFFER,
-                                                gl::COLOR_ATTACHMENT0,
-                                                gl::RENDERBUFFER,
-                                                color_renderbuffer);
-                    debug_assert!(gl::IsRenderbuffer(color_renderbuffer) == gl::TRUE);
-                },
-                ColorAttachment::Texture(texture_id) => {
-                    gl::FramebufferTexture2D(gl::FRAMEBUFFER,
+        match *self.color_attachment.as_ref().unwrap() {
+            ColorAttachment::Renderbuffer(color_renderbuffer) => {
+                gl::framebuffer_renderbuffer(gl::FRAMEBUFFER,
                                              gl::COLOR_ATTACHMENT0,
-                                             gl::TEXTURE_2D,
-                                             texture_id, 0);
-                },
-            }
+                                             gl::RENDERBUFFER,
+                                             color_renderbuffer);
+                debug_assert!(gl::is_renderbuffer(color_renderbuffer) == gl::TRUE);
+            },
+            ColorAttachment::Texture(texture_id) => {
+                gl::framebuffer_texture_2d(gl::FRAMEBUFFER,
+                                           gl::COLOR_ATTACHMENT0,
+                                           gl::TEXTURE_2D,
+                                           texture_id, 0);
+            },
+        }
 
-            if self.depth_renderbuffer != 0 {
-                gl::FramebufferRenderbuffer(gl::FRAMEBUFFER,
-                                            gl::DEPTH_ATTACHMENT,
-                                            gl::RENDERBUFFER,
-                                            self.depth_renderbuffer);
-                debug_assert!(gl::IsRenderbuffer(self.depth_renderbuffer) == gl::TRUE);
-            }
+        if self.depth_renderbuffer != 0 {
+            gl::framebuffer_renderbuffer(gl::FRAMEBUFFER,
+                                         gl::DEPTH_ATTACHMENT,
+                                         gl::RENDERBUFFER,
+                                         self.depth_renderbuffer);
+            debug_assert!(gl::is_renderbuffer(self.depth_renderbuffer) == gl::TRUE);
+        }
 
-            if self.stencil_renderbuffer != 0 {
-                gl::FramebufferRenderbuffer(gl::FRAMEBUFFER,
-                                            gl::STENCIL_ATTACHMENT,
-                                            gl::RENDERBUFFER,
-                                            self.stencil_renderbuffer);
-                debug_assert!(gl::IsRenderbuffer(self.stencil_renderbuffer) == gl::TRUE);
-            }
+        if self.stencil_renderbuffer != 0 {
+            gl::framebuffer_renderbuffer(gl::FRAMEBUFFER,
+                                         gl::STENCIL_ATTACHMENT,
+                                         gl::RENDERBUFFER,
+                                         self.stencil_renderbuffer);
+            debug_assert!(gl::is_renderbuffer(self.stencil_renderbuffer) == gl::TRUE);
         }
 
         Ok(())

--- a/src/gl_context.rs
+++ b/src/gl_context.rs
@@ -1,6 +1,6 @@
 use euclid::Size2D;
 use gleam::gl;
-use gleam::gl::types::{GLint, GLuint};
+use gleam::gl::types::{GLuint};
 
 use NativeGLContextMethods;
 use GLContextAttributes;
@@ -141,11 +141,8 @@ impl<Native> GLContext<Native>
             return db.get_framebuffer();
         }
 
-        unsafe {
-            let mut ret : GLint = 0;
-            gl::GetIntegerv(gl::FRAMEBUFFER_BINDING, &mut ret);
-            ret as GLuint
-        }
+        let ret = gl::get_integer_v(gl::FRAMEBUFFER_BINDING);
+        ret as GLuint
     }
 
     pub fn draw_buffer_size(&self) -> Option<Size2D<i32>> {
@@ -183,12 +180,10 @@ impl<T: NativeGLContextMethods> GLContextPrivateMethods for GLContext<T> {
 
         debug_assert!(self.is_current());
 
-        unsafe {
-            gl::ClearColor(0.0, 0.0, 0.0, 0.0);
-            gl::Clear(gl::COLOR_BUFFER_BIT | gl::DEPTH_BUFFER_BIT | gl::STENCIL_BUFFER_BIT);
-            gl::Scissor(0, 0, size.width, size.height);
-            gl::Viewport(0, 0, size.width, size.height);
-        }
+        gl::clear_color(0.0, 0.0, 0.0, 0.0);
+        gl::clear(gl::COLOR_BUFFER_BIT | gl::DEPTH_BUFFER_BIT | gl::STENCIL_BUFFER_BIT);
+        gl::scissor(0, 0, size.width, size.height);
+        gl::viewport(0, 0, size.width, size.height);
 
         Ok(())
     }


### PR DESCRIPTION
Fro gecko graphic branch, it is necessary to remove gl ffi usages from offscreen_gl_context.

The following is a related bug.
  https://bugzilla.mozilla.org/show_bug.cgi?id=1331546