### PR TITLE
Update gleam version constraint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ test_osmesa = []
 
 [dependencies]
 log  = "0.3"
-gleam = "0.2"
+gleam = "0.2.31"
 euclid = "0.10"
 serde = { version = "0.8", optional = true }
 osmesa-sys = { version = "0.1", optional = true }


### PR DESCRIPTION
1be3970a5702fa4696fcc3c4a98ec3bf353e9953 depends on gleam 0.2.31 or newer.