### PR TITLE
Add support for RGB8 and RGBA8 renderbuffer/texture storage formats on Android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "offscreen_gl_context"
 license = "MIT / Apache-2.0"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Emilio Cobos Álvarez <emilio@crisal.io>", "The Servo Project Developers"]
 description = "Creation and manipulation of HW accelerated offscreen rendering contexts in multiple platforms. Originally intended for the Servo project's WebGL implementation."
 repository = "https://github.com/emilio/rust-offscreen-rendering-context"

--- a/src/gl_formats.rs
+++ b/src/gl_formats.rs
@@ -44,21 +44,28 @@ impl GLFormats {
 
     #[cfg(target_os="android")]
     pub fn detect(attrs: &GLContextAttributes) -> GLFormats {
+        // detect if the GPU supports RGB8 and RGBA8 renderbuffer/texture storage formats.
+        // GL_ARM_rgba8 extension is similar to OES_rgb8_rgba8, but only exposes RGBA8.
+        let extensions = gl::get_string(gl::EXTENSIONS);
+        let extensions: Vec<&str> = extensions.split(&[',',' '][..]).collect();
+        let has_rgb8 = extensions.contains(&"GL_OES_rgb8_rgba8");
+        let has_rgba8 = has_rgb8 || extensions.contains(&"GL_ARM_rgba8");
+
         if attrs.alpha {
             GLFormats {
-                color_renderbuffer: gl::RGBA4,
+                color_renderbuffer: if has_rgba8 { gl::RGBA8 } else { gl::RGBA4 },
                 texture_internal: gl::RGBA,
                 texture: gl::RGBA,
-                texture_type: gl::UNSIGNED_SHORT_4_4_4_4,
+                texture_type: if has_rgba8 { gl::UNSIGNED_BYTE } else { gl::UNSIGNED_SHORT_4_4_4_4 },
                 depth: gl::DEPTH_COMPONENT16,
                 stencil: gl::STENCIL_INDEX8,
             }
         } else {
             GLFormats {
-                color_renderbuffer: gl::RGB565,
+                color_renderbuffer: if has_rgb8 { gl::RGB8 } else { gl::RGB565 },
                 texture_internal: gl::RGB,
                 texture: gl::RGB,
-                texture_type: gl::UNSIGNED_SHORT_4_4_4_4,
+                texture_type: if has_rgb8 { gl::UNSIGNED_BYTE } else { gl::UNSIGNED_SHORT_4_4_4_4 },
                 depth: gl::DEPTH_COMPONENT16,
                 stencil: gl::STENCIL_INDEX8,
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -23,12 +23,17 @@ extern {}
 #[link(name="GL")]
 extern {}
 
+#[cfg(not(target_os="android"))]
 static LOAD_GL: Once = ONCE_INIT;
 
+#[cfg(not(target_os="android"))]
 fn load_gl() {
     LOAD_GL.call_once(|| {
         gl::load_with(|s| GLContext::<NativeGLContext>::get_proc_address(s) as *const _);
     });
+}
+#[cfg(target_os="android")]
+fn load_gl() {
 }
 
 fn test_gl_context<T: NativeGLContextMethods>(context: &GLContext<T>) {


### PR DESCRIPTION
Hi again :)

This PR adds support for using RGB8 and RGBA8 formats on Android. Some of the tests fail on Android EGL with Invalid Operation error (tested on Nexus 4 and Google Pixel phones).  I detect if OES_rgb8_rgba8 is available to enable the new formats.