### PR TITLE
platform: Allow not depending on x11 and using only OSMesa.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "offscreen_gl_context"
 license = "MIT / Apache-2.0"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Emilio Cobos Álvarez <emilio@crisal.io>", "The Servo Project Developers"]
 description = "Creation and manipulation of HW accelerated offscreen rendering contexts in multiple platforms. Originally intended for the Servo project's WebGL implementation."
 repository = "https://github.com/emilio/rust-offscreen-rendering-context"
@@ -11,11 +11,10 @@ build = "build.rs"
 gl_generator = "0.5"
 
 [features]
-default = []
+default = ["x11"]
 osmesa = ["osmesa-sys"]
 # NOTE: Just for testing use, there are no other changes
 test_egl_in_linux = []
-test_osmesa = []
 
 [dependencies]
 log  = "0.3"
@@ -29,6 +28,7 @@ core-foundation = "0.3.0"
 cgl = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies.x11]
+optional = true
 version = "2.3.0"
 features = ["xlib"]
 

--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,7 @@ fn main() {
     let target = env::var("TARGET").unwrap();
     let dest = PathBuf::from(&env::var("OUT_DIR").unwrap());
 
-    if target.contains("linux") {
+    if target.contains("linux") && cfg!(feature = "x11") {
         let mut file = File::create(&dest.join("glx_bindings.rs")).unwrap();
         Registry::new(Api::Glx, (1, 4), Profile::Core, Fallbacks::All, [])
             .write_bindings(gl_generator::StaticGenerator, &mut file).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ extern crate log;
 #[cfg(feature="serde")]
 extern crate serde;
 
-#[cfg(target_os="linux")]
+#[cfg(all(target_os="linux", feature="x11"))]
 extern crate x11;
 #[cfg(target_os="macos")]
 extern crate cgl;
@@ -29,6 +29,7 @@ extern crate lazy_static;
 
 mod platform;
 pub use platform::{NativeGLContext, NativeGLContextMethods, NativeGLContextHandle};
+
 #[cfg(feature="osmesa")]
 pub use platform::{OSMesaContext, OSMesaContextHandle};
 
@@ -53,7 +54,7 @@ pub use gl_formats::GLFormats;
 mod gl_limits;
 pub use gl_limits::GLLimits;
 
-#[cfg(target_os="linux")]
+#[cfg(all(target_os="linux", feature="x11"))]
 #[allow(improper_ctypes)]
 mod glx {
     include!(concat!(env!("OUT_DIR"), "/glx_bindings.rs"));

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -30,15 +30,18 @@ pub trait NativeGLContextMethods: Sized {
     fn is_osmesa(&self) -> bool { false }
 }
 
-#[cfg(target_os="linux")]
+#[cfg(all(target_os="linux", feature="x11"))]
 pub mod with_glx;
-#[cfg(target_os="linux")]
+#[cfg(all(target_os="linux", feature="x11"))]
 pub use self::with_glx::{NativeGLContext, NativeGLContextHandle};
 
 #[cfg(feature="osmesa")]
 pub mod with_osmesa;
 #[cfg(feature="osmesa")]
 pub use self::with_osmesa::{OSMesaContext, OSMesaContextHandle};
+#[cfg(all(target_os="linux", not(feature="x11")))]
+pub use self::with_osmesa::{OSMesaContext as NativeGLContext, OSMesaContextHandle as NativeGLContextHandle};
+
 
 #[cfg(any(target_os="android", all(target_os="linux", feature = "test_egl_in_linux")))]
 pub mod with_egl;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -18,7 +18,7 @@ use std::sync::mpsc;
 #[link(name="OpenGL", kind="framework")]
 extern {}
 
-#[cfg(target_os="linux")]
+#[cfg(all(target_os="linux", feature="x11"))]
 #[link(name="GL")]
 extern {}
 


### PR DESCRIPTION
Fixes #88 

You can build this with `--no-default-features --features osmesa`. I've tested it with a server without X11 installed.