### PR TITLE
Fix eglGetProcAddress for core OpenGL entrypoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "offscreen_gl_context"
 license = "MIT / Apache-2.0"
-version = "0.8.4"
+version = "0.8.5"
 authors = ["Emilio Cobos Álvarez <emilio@crisal.io>", "The Servo Project Developers"]
 description = "Creation and manipulation of HW accelerated offscreen rendering contexts in multiple platforms. Originally intended for the Servo project's WebGL implementation."
 repository = "https://github.com/emilio/rust-offscreen-rendering-context"
@@ -14,7 +14,7 @@ gl_generator = "0.5"
 default = ["x11"]
 osmesa = ["osmesa-sys"]
 # NOTE: Just for testing use, there are no other changes
-test_egl_in_linux = []
+test_egl_in_linux = ["libloading", "lazy_static"]
 
 [dependencies]
 log  = "0.3"
@@ -22,6 +22,8 @@ gleam = "0.4"
 euclid = "0.11"
 serde = { version = "0.9", optional = true }
 osmesa-sys = { version = "0.1", optional = true }
+libloading = { version = "0.3", optional = true }
+lazy_static = { version = "0.2", optional = true }
 
 [target.x86_64-apple-darwin.dependencies]
 core-foundation = "0.3.0"
@@ -38,5 +40,8 @@ gdi32-sys = "0.2"
 user32-sys = "0.2"
 kernel32-sys = "0.2"
 
-[target.'cfg(any(target_os="macos", target_os="windows"))'.dependencies]
+[target.'cfg(any(target_os="macos", target_os="windows", target_os="android"))'.dependencies]
 lazy_static = "0.2"
+
+[target.'cfg(target_os = "android")'.dependencies]
+libloading = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,11 @@ extern crate kernel32;
 extern crate gdi32;
 #[cfg(target_os = "windows")]
 extern crate user32;
-#[cfg(any(target_os="macos", target_os="windows"))]
+#[cfg(any(target_os="macos", target_os="windows", target_os="android", feature="test_egl_in_linux"))]
 #[macro_use]
 extern crate lazy_static;
+#[cfg(any(target_os="android", feature="test_egl_in_linux"))]
+extern crate libloading;
 
 mod platform;
 pub use platform::{NativeGLContext, NativeGLContextMethods, NativeGLContextHandle};


### PR DESCRIPTION
Hi,

The upgrade to the new gleam has broken offscreen EGL based contexts & Android WebGL on Servo. This is because eglProcAddress can't be used to resolve core OpenGL function entry points on many implementations. Loading core functions with eglProcAddress is only possible in EGL 1.5.

