### PR TITLE
Fix EGL compilation error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "offscreen_gl_context"
 license = "MIT / Apache-2.0"
-version = "0.8.5"
+version = "0.8.6"
 authors = ["Emilio Cobos Álvarez <emilio@crisal.io>", "The Servo Project Developers"]
 description = "Creation and manipulation of HW accelerated offscreen rendering contexts in multiple platforms. Originally intended for the Servo project's WebGL implementation."
 repository = "https://github.com/emilio/rust-offscreen-rendering-context"

--- a/src/platform/with_egl/native_gl_context.rs
+++ b/src/platform/with_egl/native_gl_context.rs
@@ -11,7 +11,7 @@ lazy_static! {
     static ref GL_LIB: Option<lib::Library>  = {
        let names = ["libGLESv2.so", "libGL.so", "libGLESv3.so"];
        for name in &names {
-           if let Ok(lib) = Library::new(name) 
+           if let Ok(lib) = lib::Library::new(name) {
                return Some(lib)
            }
        }


### PR DESCRIPTION
I pushed a compilation error in the latest PR after compiling for desktop with test_egl_in_linux disabled... 

I'll add android compilation to travis to prevent this from happening again.