### PR TITLE
Antialias attribute shall not cause a failure to create a WebGLRenderingContext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "offscreen_gl_context"
 license = "MIT / Apache-2.0"
-version = "0.8.7"
+version = "0.8.8"
 authors = ["Emilio Cobos Álvarez <emilio@crisal.io>", "The Servo Project Developers"]
 description = "Creation and manipulation of HW accelerated offscreen rendering contexts in multiple platforms. Originally intended for the Servo project's WebGL implementation."
 repository = "https://github.com/emilio/rust-offscreen-rendering-context"

--- a/src/draw_buffer.rs
+++ b/src/draw_buffer.rs
@@ -91,8 +91,10 @@ impl DrawBuffer {
         debug!("Creating draw buffer {:?}, {:?}, attrs: {:?}, caps: {:?}",
                size, color_attachment_type, attrs, capabilities);
 
+        // WebGL spec: antialias attribute is a requests, not a requirement.
+        // If not supported it shall not cause a failure to create a WebGLRenderingContext.
         if attrs.antialias && capabilities.max_samples == 0 {
-            return Err("The given GLContext doesn't support requested antialising");
+            error!("The given GLContext doesn't support requested antialising");
         }
 
         if attrs.preserve_drawing_buffer {


### PR DESCRIPTION
WebGL spec:

> **The depth, stencil and antialias attributes, when set to true, are requests, not requirements**. The WebGL implementation should make a best effort to honor them. When any of these attributes is set to false, however, the WebGL implementation must not provide the associated functionality. **Combinations of attributes not supported by the WebGL implementation or graphics hardware shall not cause a failure to create a WebGLRenderingContext**. The actual context parameters are set to the attributes of the created drawing buffer. The alpha, premultipliedAlpha and preserveDrawingBuffer attributes must be obeyed by the WebGL implementation. 