### PR TITLE
Bump libloading to 0.4 without default-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "offscreen_gl_context"
 license = "MIT / Apache-2.0"
-version = "0.8.8"
+version = "0.8.9"
 authors = ["Emilio Cobos Álvarez <emilio@crisal.io>", "The Servo Project Developers"]
 description = "Creation and manipulation of HW accelerated offscreen rendering contexts in multiple platforms. Originally intended for the Servo project's WebGL implementation."
 repository = "https://github.com/emilio/rust-offscreen-rendering-context"
@@ -22,7 +22,7 @@ gleam = "0.4"
 euclid = "0.11"
 serde = { version = "0.9", optional = true }
 osmesa-sys = { version = "0.1", optional = true }
-libloading = { version = "0.3", optional = true }
+libloading = { version = "0.4", optional = true, default-features = false }
 lazy_static = { version = "0.2", optional = true }
 
 [target.x86_64-apple-darwin.dependencies]
@@ -44,4 +44,4 @@ kernel32-sys = "0.2"
 lazy_static = "0.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
-libloading = "0.3"
+libloading = { version = "0.4", default-features = false }


### PR DESCRIPTION
This removes the dependency on serde_json from target-build-utils.