### PR TITLE
Fix shared EGL Context  creation faliure on some Android GPUs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "offscreen_gl_context"
 license = "MIT / Apache-2.0"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Emilio Cobos Álvarez <emilio@crisal.io>", "The Servo Project Developers"]
 description = "Creation and manipulation of HW accelerated offscreen rendering contexts in multiple platforms. Originally intended for the Servo project's WebGL implementation."
 repository = "https://github.com/emilio/rust-offscreen-rendering-context"


### PR DESCRIPTION
Shared EGL Context creation fails in Samsung Galaxy S7 (GPU Mali-T880). This fail only happens when the context to share from uses a different CLIENT_API_VERSION than the one we are setting in NativeGLContext::new().

This issue reminded me the sharing problems on Mac OS https://github.com/emilio/rust-offscreen-rendering-context/issues/82  but after some testing I found a workaround. Setting CLIENT_API_VERSION to 3 fixes the issue and it's still OPENGL_ES 2 compliant thanks to using the egl::OPENGL_ES2_BIT for egl::RENDERABLE_TYPE. I was able to run some WebGL demos with this configuration.

