### PR TITLE
Implement EAGL api for iOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "offscreen_gl_context"
 license = "MIT / Apache-2.0"
-version = "0.11.2"
+version = "0.12.0"
 authors = ["Emilio Cobos Álvarez <emilio@crisal.io>", "The Servo Project Developers"]
 description = "Creation and manipulation of HW accelerated offscreen rendering contexts in multiple platforms. Originally intended for the Servo project's WebGL implementation."
 repository = "https://github.com/emilio/rust-offscreen-rendering-context"
@@ -18,7 +18,7 @@ test_egl_in_linux = ["libloading", "lazy_static"]
 
 [dependencies]
 log  = "0.3"
-gleam = "0.4.9"
+gleam = "0.4.10"
 euclid = "0.15"
 serde = { version = "1.0", optional = true }
 osmesa-sys = { version = "0.1", optional = true }
@@ -29,7 +29,11 @@ lazy_static = { version = "0.2", optional = true }
 core-foundation = "0.4"
 cgl = "0.2"
 
-[target.'cfg(all(unix, not(any(target_os = "macos", target_os = "android"))))'.dependencies.x11]
+[target.'cfg(target_os = "ios")'.dependencies]
+objc = "0.2"
+libloading = { version = "0.4", default-features = false }
+
+[target.'cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_os = "ios"))))'.dependencies.x11]
 optional = true
 version = "2.3.0"
 features = ["xlib"]
@@ -40,7 +44,7 @@ gdi32-sys = "0.2"
 user32-sys = "0.2"
 kernel32-sys = "0.2"
 
-[target.'cfg(any(target_os="macos", target_os="windows", target_os="android"))'.dependencies]
+[target.'cfg(any(target_os="macos", target_os="windows", target_os="android", target_os="ios"))'.dependencies]
 lazy_static = "0.2"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,10 @@ fn main() {
         println!("cargo:rustc-link-lib=EGL");
     }
 
+    if target.contains("apple-ios") {
+        println!("cargo:rustc-link-lib=framework=OpenGLES");
+    }
+
     if target.contains("darwin") {
         println!("cargo:rustc-link-lib=framework=OpenGL");
     } else if target.contains("windows") {
@@ -43,7 +47,7 @@ fn main() {
             .write_bindings(gl_generator::StructGenerator, &mut file).unwrap();
 
         println!("cargo:rustc-link-lib=opengl32");
-    } else if cfg!(feature = "x11") && !target.contains("android") {
+    } else if cfg!(feature = "x11") && !target.contains("android") && !target.contains("apple-ios") {
         let mut file = File::create(&dest.join("glx_bindings.rs")).unwrap();
         Registry::new(Api::Glx, (1, 4), Profile::Core, Fallbacks::All, [])
             .write_bindings(gl_generator::StaticGenerator, &mut file).unwrap();

--- a/src/gl_formats.rs
+++ b/src/gl_formats.rs
@@ -21,7 +21,7 @@ impl GLFormats {
     //
     // FIXME: In linux with GLES2 texture attachments create INVALID_ENUM errors.
     // I suspect that it's because of texture formats, but I need time to debugit.
-    #[cfg(not(target_os="android"))]
+    #[cfg(not(any(target_os="android", target_os="ios")))]
     pub fn detect(attrs: &GLContextAttributes, extensions: &[String], api_version: GLVersion) -> GLFormats {
         let packed_depth_stencil = GLFormats::supports_packed_depth_stencil(&extensions, api_version);
 
@@ -48,11 +48,12 @@ impl GLFormats {
         }
     }
 
-    #[cfg(target_os="android")]
+    #[cfg(any(target_os="android", target_os="ios"))]
     pub fn detect(attrs: &GLContextAttributes, extensions: &[String], api_version: GLVersion) -> GLFormats {
-        // detect if the GPU supports RGB8 and RGBA8 renderbuffer/texture storage formats.
+        // RGB8 or RGBA8 is guaranteed on OpenGLES 3+.
+        // On OpenGLES 2 detect via extensions if the GPU supports RGB8 and RGBA8 renderbuffer/texture storage formats.
         // GL_ARM_rgba8 extension is similar to OES_rgb8_rgba8, but only exposes RGBA8.
-        let has_rgb8 = extensions.iter().any(|s| s == "GL_OES_rgb8_rgba8");
+        let has_rgb8 = api_version.major_version() >= 3 || extensions.iter().any(|s| s == "GL_OES_rgb8_rgba8");
         let has_rgba8 = has_rgb8 || extensions.iter().any(|s| s == "GL_ARM_rgba8");
 
         let packed_depth_stencil = GLFormats::supports_packed_depth_stencil(&extensions, api_version);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ extern crate log;
 #[cfg(feature="serde")]
 extern crate serde;
 
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "android")), feature="x11"))]
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_os = "ios")), feature="x11"))]
 extern crate x11;
 #[cfg(target_os="macos")]
 extern crate cgl;
@@ -23,11 +23,14 @@ extern crate kernel32;
 extern crate gdi32;
 #[cfg(target_os = "windows")]
 extern crate user32;
-#[cfg(any(target_os="macos", target_os="windows", target_os="android", feature="test_egl_in_linux"))]
+#[cfg(any(target_os="macos", target_os="windows", target_os="android", target_os="ios", feature="test_egl_in_linux"))]
 #[macro_use]
 extern crate lazy_static;
-#[cfg(any(target_os="android", feature="test_egl_in_linux"))]
+#[cfg(any(target_os="android", target_os="ios", feature="test_egl_in_linux"))]
 extern crate libloading;
+#[cfg(target_os = "ios")]
+#[macro_use]
+extern crate objc;
 
 mod platform;
 pub use platform::{NativeGLContext, NativeGLContextMethods, NativeGLContextHandle};
@@ -56,13 +59,13 @@ pub use gl_formats::GLFormats;
 mod gl_limits;
 pub use gl_limits::GLLimits;
 
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "android")), feature="x11"))]
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_os = "ios")), feature="x11"))]
 #[allow(improper_ctypes)]
 mod glx {
     include!(concat!(env!("OUT_DIR"), "/glx_bindings.rs"));
 }
 
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "android")), feature="x11"))]
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_os = "ios")), feature="x11"))]
 #[allow(improper_ctypes)]
 mod glx_extra {
     include!(concat!(env!("OUT_DIR"), "/glx_extra_bindings.rs"));

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -36,9 +36,9 @@ pub trait NativeGLContextMethods: Sized {
     fn is_osmesa(&self) -> bool { false }
 }
 
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "android")), feature="x11"))]
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_os = "ios")), feature="x11"))]
 pub mod with_glx;
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "android")), feature="x11"))]
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_os = "ios")), feature="x11"))]
 pub use self::with_glx::{NativeGLContext, NativeGLContextHandle};
 
 #[cfg(feature="osmesa")]
@@ -63,6 +63,11 @@ pub use self::with_cgl::{NativeGLContext, NativeGLContextHandle};
 pub mod with_wgl;
 #[cfg(target_os="windows")]
 pub use self::with_wgl::{NativeGLContext, NativeGLContextHandle};
+
+#[cfg(target_os="ios")]
+pub mod with_eagl;
+#[cfg(target_os="ios")]
+pub use self::with_eagl::{NativeGLContext, NativeGLContextHandle};
 
 #[cfg(not(any(unix, target_os="windows")))]
 pub mod not_implemented;

--- a/src/platform/with_eagl/mod.rs
+++ b/src/platform/with_eagl/mod.rs
@@ -1,0 +1,3 @@
+mod native_gl_context;
+pub use self::native_gl_context::NativeGLContext;
+pub use self::native_gl_context::NativeGLContextHandle;

--- a/src/platform/with_eagl/native_gl_context.rs
+++ b/src/platform/with_eagl/native_gl_context.rs
@@ -1,0 +1,140 @@
+use platform::NativeGLContextMethods;
+use GLVersion;
+use gleam::gl;
+use objc::runtime::{BOOL, NO};
+use objc::runtime::{Class, Object};
+use libloading as lib;
+use std::ops::Deref;
+use std::ptr;
+
+type EAGLContext = *mut Object;
+type EAGLSharegroup = *mut Object;
+
+lazy_static! {
+    static ref EAGLCONTEXT_CLASS: &'static Class  = {
+        Class::get("EAGLContext").expect("EAGLContext class not found")
+    };
+
+    static ref OPENGLES_FRAMEWORK: Option<lib::Library>  = {
+        lib::Library::new("/System/Library/Frameworks/OpenGLES.framework/OpenGLES").ok()
+    };
+}
+
+pub struct NativeGLContext(EAGLContext);
+pub type NativeGLContextHandle = NativeGLContext;
+unsafe impl Send for NativeGLContext {}
+
+impl NativeGLContext {
+    fn new_retained(context: EAGLContext) -> Self {
+        let context = unsafe { msg_send![context, retain] };
+        NativeGLContext(context)
+    }
+}
+
+impl Drop for NativeGLContext {
+    fn drop(&mut self) {
+        unsafe {
+            msg_send![self.0, release];
+        }
+    }
+}
+
+impl NativeGLContextMethods for NativeGLContext {
+    type Handle = Self;
+
+    fn get_proc_address(addr: &str) -> *const () {
+        let framework = match *OPENGLES_FRAMEWORK {
+            Some(ref lib) => lib,
+            None => return ptr::null(),
+        };
+        unsafe {
+            let symbol: Result<lib::Symbol<unsafe extern fn()>, _> = framework.get(addr.as_bytes());
+            match symbol {
+                Ok(symbol) => *symbol.deref() as *const (),
+                _ => ptr::null()
+            }
+        }
+    }
+
+    fn create_shared(with: Option<&Self::Handle>,
+                     api_type: &gl::GlType,
+                     api_version: GLVersion) -> Result<NativeGLContext, &'static str> {
+        match *api_type {
+            gl::GlType::Gles => {},
+            _ => return Err("Only OpenGL ES is supported on iOS"),
+        }
+        let context: EAGLContext = unsafe {
+            let context: EAGLContext = msg_send![*EAGLCONTEXT_CLASS, alloc];
+            let version = api_version.major_version() as u32;
+            match with {
+                Some(with) => {
+                    let sharegroup: EAGLSharegroup = msg_send![with.0, sharegroup];
+                    msg_send![context, initWithAPI: version sharegroup: sharegroup]
+                },
+                None => msg_send![context, initWithAPI: version]
+            }
+        };
+
+        if context.is_null() {
+            Err("[EAGLContext initWithAPI] failed")
+        } else {
+            // Instance already retained by the alloc call. No need to call NativeGLContext::new_retained.
+            Ok(NativeGLContext(context))
+        }
+    }
+
+    fn is_current(&self) -> bool {
+        match Self::current_handle() {
+            Some(handle) => handle.0 == self.0,
+            None => false
+        }
+    }
+
+    fn current() -> Option<Self> {
+        let context: EAGLContext = unsafe {
+            msg_send![*EAGLCONTEXT_CLASS, currentContext]
+        };
+        if context.is_null() {
+            None
+        } else {
+            Some(NativeGLContext::new_retained(context))
+        }
+    }
+
+    fn current_handle() -> Option<Self::Handle> {
+        let context: EAGLContext = unsafe {
+            msg_send![*EAGLCONTEXT_CLASS, currentContext]
+        };
+        if context.is_null() {
+            None
+        } else {
+            Some(NativeGLContext::new_retained(context))
+        }
+    }
+
+    fn make_current(&self) -> Result<(), &'static str> {
+        let succeeded: BOOL = unsafe {
+            msg_send![*EAGLCONTEXT_CLASS, setCurrentContext: self.0]
+        };
+        if succeeded == NO {
+            Err("[EAGLContext setCurrentContext: context] failed")
+        } else {
+            Ok(())
+        }
+    }
+
+    fn unbind(&self) -> Result<(), &'static str> {
+        let succeeded: BOOL = unsafe {
+            msg_send![*EAGLCONTEXT_CLASS, setCurrentContext: 0 as EAGLContext]
+        };
+        if succeeded == NO {
+            Err("[EAGLContext setCurrentContext: nil] failed")
+        } else {
+            Ok(())
+        }
+    }
+
+    fn handle(&self) -> Self::Handle {
+        NativeGLContext::new_retained(self.0)
+    }
+}


### PR DESCRIPTION
Implement EAGL api for iOS.  All the tests are passing.

Note: you can use `cargo dinghy test --target x86_64-apple-ios` for easy testing using an iPhone emulator on MacOS