### PR TITLE
Fix OSMesa context creation error for GL 3.x versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "offscreen_gl_context"
 license = "MIT / Apache-2.0"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Emilio Cobos Álvarez <emilio@crisal.io>", "The Servo Project Developers"]
 description = "Creation and manipulation of HW accelerated offscreen rendering contexts in multiple platforms. Originally intended for the Servo project's WebGL implementation."
 repository = "https://github.com/emilio/rust-offscreen-rendering-context"

--- a/src/platform/with_osmesa/mod.rs
+++ b/src/platform/with_osmesa/mod.rs
@@ -38,7 +38,10 @@ impl OSMesaContext {
         }
 
         let (major, minor) = match api_version {
-            GLVersion::Major(major) => (major, 1), // OpenGL 2.1, 3.1
+            // OSMesa only supports compatibility (non-Core) profiles in GL versions <= 3.0.
+            // A 3.0 compatibility profile is preferred for a major 3 context version (e.g. WebGL 2).
+            // A 2.1 profile is created for a major 2 context version (e.g. WebGL 1).
+            GLVersion::Major(major) => (major, if major >= 3 { 0 } else { 1 }),
             GLVersion::MajorMinor(major, minor) => (major, minor)
         };
 


### PR DESCRIPTION
OSMesa context creation fails on Servo headless mode tests when using webgl 2.0 contexts. 

This happens because OSMesa uses a OSMESA_COMPAT_PROFILE  by default and it seems that it only supports compatibility  profiles in GL versions <= 3.0 and core profiles for >= 3.1

With this PR:
A 3.0 compatibility profile is preferred for a major 3 context version (e.g. WebGL 2).
A 2.1 profile is created for a major 2 context version (e.g. WebGL 1).

In the future we could include a new setting to select Core/Compatibility profiles for all the backends.