### PR TITLE
Fix up linking on Windows.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "offscreen_gl_context"
 license = "MIT / Apache-2.0"
 edition = "2018"
-version = "0.22.2"
+version = "0.22.3"
 authors = ["Emilio Cobos Álvarez <emilio@crisal.io>", "The Servo Project Developers"]
 description = "Creation and manipulation of HW accelerated offscreen rendering contexts in multiple platforms. Originally intended for the Servo project's WebGL implementation."
 repository = "https://github.com/servo/rust-offscreen-rendering-context"

--- a/build.rs
+++ b/build.rs
@@ -16,7 +16,16 @@ fn main() {
         let mut file = File::create(&dest.join("egl_bindings.rs")).unwrap();
         Registry::new(Api::Egl, (1, 5), Profile::Core, Fallbacks::All, [])
             .write_bindings(gl_generator::StaticGenerator, &mut file).unwrap();
-        println!("cargo:rustc-link-lib=EGL");
+
+        // Historically, Android builds have succeeded with rust-link-lib=EGL.
+        // On Windows when relying on %LIBS% to contain libEGL.lib, however,
+        // we must explicitly use rustc-link-lib=libEGL or rustc will attempt
+        // to link EGL.lib instead.
+        if target.contains("windows") {
+            println!("cargo:rustc-link-lib=libEGL");
+        } else {
+            println!("cargo:rust-link-lib=EGL");
+        }
     }
 
     if target.contains("apple-ios") {


### PR DESCRIPTION
This is required for the UWP Servo build.