### PR TITLE
Do not fail if preserveDrawingBuffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "offscreen_gl_context"
 license = "MIT / Apache-2.0"
 edition = "2018"
-version = "0.25.0"
+version = "0.25.1"
 authors = ["Emilio Cobos Álvarez <emilio@crisal.io>", "The Servo Project Developers"]
 description = "Creation and manipulation of HW accelerated offscreen rendering contexts in multiple platforms. Originally intended for the Servo project's WebGL implementation."
 repository = "https://github.com/servo/rust-offscreen-rendering-context"

--- a/src/draw_buffer.rs
+++ b/src/draw_buffer.rs
@@ -98,7 +98,7 @@ impl DrawBuffer {
         }
 
         if attrs.preserve_drawing_buffer {
-            return Err("preserveDrawingBuffer is not supported yet");
+            error!("preserveDrawingBuffer is not supported yet");
         }
 
         // See https://github.com/servo/servo/issues/12320


### PR DESCRIPTION
The hard fail breaks babylonjs demos.

See https://github.com/servo/servo/issues/21132