### PR TITLE
Fix so the compiler can infer msg_send! return type

### DIFF
--- a/src/platform/with_eagl/native_gl_context.rs
+++ b/src/platform/with_eagl/native_gl_context.rs
@@ -34,7 +34,7 @@ impl NativeGLContext {
 impl Drop for NativeGLContext {
     fn drop(&mut self) {
         unsafe {
-            msg_send![self.0, release];
+            let () = msg_send![self.0, release];
         }
     }
 }


### PR DESCRIPTION
Currently, due to a quirk in Rust's type inference interacting with the structure of the `msg_send!` macro, a `()` return type will be inferred when the compiler cannot otherwise determine the return type. This behavior is expected to change, and in the future could resolve to a `!` return type, which results in undefined behavior.

Linting has previously been added for this in rust-lang/rust#39216, but it did not catch these cases due to SSheldon/rust-objc#62. objc has been fixed to stop hiding these errors as of version 0.2.7, and they are now compile errors.

This change fixes these errors and allows compiling with the latest version of objc.