### PR TITLE
Add a method to Connection to get the GL API

### DIFF
--- a/surfman/src/connection.rs
+++ b/surfman/src/connection.rs
@@ -3,6 +3,7 @@
 //! The abstract interface that all connections conform to.
 
 use crate::Error;
+use crate::GLApi;
 
 #[cfg(feature = "sm-winit")]
 use winit::Window;
@@ -25,6 +26,9 @@ pub trait Connection: Sized {
 
     /// Returns the native connection corresponding to this connection.
     fn native_connection(&self) -> Self::NativeConnection;
+
+    /// Returns the OpenGL API flavor that this connection supports (OpenGL or OpenGL ES).
+    fn gl_api(&self) -> GLApi;
 
     /// Returns the "best" adapter on this system, preferring high-performance hardware adapters.
     /// 

--- a/surfman/src/implementation/connection.rs
+++ b/surfman/src/implementation/connection.rs
@@ -5,6 +5,7 @@
 
 use crate::Error;
 use crate::connection::Connection as ConnectionInterface;
+use crate::info::GLApi;
 use super::super::connection::{Connection, NativeConnection};
 use super::super::device::{Adapter, Device, NativeDevice};
 use super::super::surface::NativeWidget;
@@ -27,6 +28,11 @@ impl ConnectionInterface for Connection {
     #[inline]
     fn native_connection(&self) -> Self::NativeConnection {
         Connection::native_connection(self)
+    }
+
+    #[inline]
+    fn gl_api(&self) -> GLApi {
+        Connection::gl_api(self)
     }
 
     #[inline]

--- a/surfman/src/platform/android/connection.rs
+++ b/surfman/src/platform/android/connection.rs
@@ -5,6 +5,7 @@
 //! FIXME(pcwalton): Should this instead wrap `EGLDisplay`? Is that thread-safe on Android?
 
 use crate::Error;
+use crate::GLApi;
 use super::device::{Adapter, Device, NativeDevice};
 use super::surface::NativeWidget;
 
@@ -36,6 +37,12 @@ impl Connection {
     #[inline]
     pub fn native_connection(&self) -> NativeConnection {
         NativeConnection
+    }
+
+    /// Returns the OpenGL API flavor that this connection supports (OpenGL or OpenGL ES).
+    #[inline]
+    pub fn gl_api(&self) -> GLApi {
+        GLApi::GLES
     }
 
     /// Returns the "best" adapter on this system.

--- a/surfman/src/platform/generic/multi/connection.rs
+++ b/surfman/src/platform/generic/multi/connection.rs
@@ -3,6 +3,7 @@
 //! A connection abstraction that allows the choice of backends dynamically.
 
 use crate::Error;
+use crate::GLApi;
 use crate::connection::Connection as ConnectionInterface;
 use crate::device::Device as DeviceInterface;
 use super::device::{Adapter, Device, NativeDevice};
@@ -70,6 +71,14 @@ impl<Def, Alt> Connection<Def, Alt>
             Connection::Alternate(ref connection) => {
                 NativeConnection::Alternate(connection.native_connection())
             }
+        }
+    }
+
+    /// Returns the OpenGL API flavor that this connection supports (OpenGL or OpenGL ES).
+    pub fn gl_api(&self) -> GLApi {
+        match *self {
+            Connection::Default(ref connection) => connection.gl_api(),
+            Connection::Alternate(ref connection) => connection.gl_api(),
         }
     }
 
@@ -211,6 +220,11 @@ impl<Def, Alt> ConnectionInterface for Connection<Def, Alt>
     #[inline]
     fn native_connection(&self) -> NativeConnection<Def, Alt> {
         Connection::native_connection(self)
+    }
+
+    #[inline]
+    fn gl_api(&self) -> GLApi {
+        Connection::gl_api(self)
     }
 
     #[inline]

--- a/surfman/src/platform/macos/cgl/connection.rs
+++ b/surfman/src/platform/macos/cgl/connection.rs
@@ -6,6 +6,7 @@
 //! global window server connection.
 
 use crate::Error;
+use crate::GLApi;
 use crate::platform::macos::system::connection::Connection as SystemConnection;
 use crate::platform::macos::system::device::NativeDevice;
 use crate::platform::macos::system::surface::NativeWidget;
@@ -38,6 +39,12 @@ impl Connection {
     #[inline]
     pub fn native_connection(&self) -> NativeConnection {
         self.0.native_connection()
+    }
+
+    /// Returns the OpenGL API flavor that this connection supports (OpenGL or OpenGL ES).
+    #[inline]
+    pub fn gl_api(&self) -> GLApi {
+        GLApi::GL
     }
 
     /// Returns the "best" adapter on this system, preferring high-performance hardware adapters.

--- a/surfman/src/platform/unix/generic/connection.rs
+++ b/surfman/src/platform/unix/generic/connection.rs
@@ -5,6 +5,7 @@
 use crate::Error;
 use crate::egl::types::{EGLAttrib, EGLDisplay};
 use crate::egl;
+use crate::info::GLApi;
 use crate::platform::generic::egl::device::EGL_FUNCTIONS;
 use crate::platform::generic::egl::ffi::EGL_PLATFORM_SURFACELESS_MESA;
 use super::device::{Adapter, Device, NativeDevice};
@@ -76,6 +77,12 @@ impl Connection {
     #[inline]
     pub fn native_connection(&self) -> NativeConnection {
         NativeConnection(self.native_connection.clone())
+    }
+
+    /// Returns the OpenGL API flavor that this connection supports (OpenGL or OpenGL ES).
+    #[inline]
+    pub fn gl_api(&self) -> GLApi {
+        GLApi::GL
     }
 
     /// Returns the "best" adapter on this system, preferring high-performance hardware adapters.

--- a/surfman/src/platform/unix/wayland/connection.rs
+++ b/surfman/src/platform/unix/wayland/connection.rs
@@ -5,6 +5,7 @@
 use crate::Error;
 use crate::egl::types::{EGLAttrib, EGLDisplay};
 use crate::egl;
+use crate::info::GLApi;
 use crate::platform::generic::egl::device::EGL_FUNCTIONS;
 use crate::platform::generic::egl::ffi::EGL_PLATFORM_WAYLAND_KHR;
 use super::device::{Adapter, Device, NativeDevice};
@@ -61,6 +62,12 @@ impl Connection {
     #[inline]
     pub fn native_connection(&self) -> NativeConnection {
         NativeConnection(self.native_connection.egl_display)
+    }
+
+    /// Returns the OpenGL API flavor that this connection supports (OpenGL or OpenGL ES).
+    #[inline]
+    pub fn gl_api(&self) -> GLApi {
+        GLApi::GL
     }
 
     /// Returns the "best" adapter on this system, preferring high-performance hardware adapters.

--- a/surfman/src/platform/unix/x11/connection.rs
+++ b/surfman/src/platform/unix/x11/connection.rs
@@ -5,6 +5,7 @@
 use crate::egl::types::{EGLAttrib, EGLDisplay};
 use crate::egl;
 use crate::error::Error;
+use crate::info::GLApi;
 use crate::platform::generic::egl::device::EGL_FUNCTIONS;
 use crate::platform::generic::egl::ffi::EGL_PLATFORM_X11_KHR;
 use crate::platform::unix::generic::device::Adapter;
@@ -134,6 +135,12 @@ impl Connection {
             egl_display: self.native_connection.egl_display,
             x11_display: self.native_connection.x11_display,
         }
+    }
+
+    /// Returns the OpenGL API flavor that this connection supports (OpenGL or OpenGL ES).
+    #[inline]
+    pub fn gl_api(&self) -> GLApi {
+        GLApi::GL
     }
 
     /// Returns the "best" adapter on this system, preferring high-performance hardware adapters.

--- a/surfman/src/platform/windows/angle/connection.rs
+++ b/surfman/src/platform/windows/angle/connection.rs
@@ -8,6 +8,7 @@
 //! implicit in the Win32 API, and as such this type is a no-op.
 
 use crate::Error;
+use crate::GLApi;
 use super::device::{Adapter, Device, NativeDevice, VendorPreference};
 use super::surface::NativeWidget;
 
@@ -57,6 +58,12 @@ impl Connection {
     #[inline]
     pub fn native_connection(&self) -> NativeConnection {
         NativeConnection
+    }
+
+    /// Returns the OpenGL API flavor that this connection supports (OpenGL or OpenGL ES).
+    #[inline]
+    pub fn gl_api(&self) -> GLApi {
+        GLApi::GLES
     }
 
     /// Returns the "best" adapter on this system, preferring high-performance hardware adapters.

--- a/surfman/src/platform/windows/wgl/connection.rs
+++ b/surfman/src/platform/windows/wgl/connection.rs
@@ -5,6 +5,7 @@
 //! Window server connections are implicit in the Win32 API, so this is a zero-sized type.
 
 use crate::Error;
+use crate::GLApi;
 use super::device::{Adapter, Device, NativeDevice};
 use super::surface::NativeWidget;
 
@@ -44,6 +45,12 @@ impl Connection {
     #[inline]
     pub fn native_connection(&self) -> NativeConnection {
         NativeConnection
+    }
+
+    /// Returns the OpenGL API flavor that this connection supports (OpenGL or OpenGL ES).
+    #[inline]
+    pub fn gl_api(&self) -> GLApi {
+        GLApi::GL
     }
 
     /// Returns the "best" adapter on this system, preferring high-performance hardware adapters.


### PR DESCRIPTION
Allow users to get the GL API of a connection without creating a `Device`.