### PR TITLE
Add check for unconditional recursion, to error if we forget to implement a function

### DIFF
--- a/surfman/src/implementation/connection.rs
+++ b/surfman/src/implementation/connection.rs
@@ -12,6 +12,7 @@ use super::super::surface::NativeWidget;
 #[cfg(feature = "sm-winit")]
 use winit::Window;
 
+#[deny(unconditional_recursion)]
 impl ConnectionInterface for Connection {
     type Adapter = Adapter;
     type Device = Device;

--- a/surfman/src/implementation/device.rs
+++ b/surfman/src/implementation/device.rs
@@ -14,6 +14,7 @@ use super::super::surface::{NativeWidget, Surface, SurfaceTexture};
 
 use std::os::raw::c_void;
 
+#[deny(unconditional_recursion)]
 impl DeviceInterface for Device {
     type Connection = Connection;
     type Context = Context;


### PR DESCRIPTION
At the moment, if a back end forgets to implement one of the trait functions, surfman still builds, but goes into an infinite loop when the function is called. This has bitten me more than once, but is easy to protect against.