### PR TITLE
An API for creating a native widget from a raw pointer

### DIFF
--- a/surfman/src/connection.rs
+++ b/surfman/src/connection.rs
@@ -5,6 +5,10 @@
 use crate::Error;
 use crate::GLApi;
 
+use euclid::default::Size2D;
+
+use std::os::raw::c_void;
+
 #[cfg(feature = "sm-winit")]
 use winit::Window;
 
@@ -61,4 +65,7 @@ pub trait Connection: Sized {
     #[cfg(feature = "sm-winit")]
     fn create_native_widget_from_winit_window(&self, window: &Window)
                                               -> Result<Self::NativeWidget, Error>;
+
+    /// Creates a native widget from a raw pointer
+    unsafe fn create_native_widget_from_ptr(&self, raw: *mut c_void, size: Size2D<i32>) -> Self::NativeWidget;
 }

--- a/surfman/src/implementation/connection.rs
+++ b/surfman/src/implementation/connection.rs
@@ -10,6 +10,10 @@ use super::super::connection::{Connection, NativeConnection};
 use super::super::device::{Adapter, Device, NativeDevice};
 use super::super::surface::NativeWidget;
 
+use euclid::default::Size2D;
+
+use std::os::raw::c_void;
+
 #[cfg(feature = "sm-winit")]
 use winit::Window;
 
@@ -78,5 +82,10 @@ impl ConnectionInterface for Connection {
     fn create_native_widget_from_winit_window(&self, window: &Window)
                                               -> Result<NativeWidget, Error> {
         Connection::create_native_widget_from_winit_window(self, window)
+    }
+
+    #[inline]
+    unsafe fn create_native_widget_from_ptr(&self, raw: *mut c_void, size: Size2D<i32>) -> NativeWidget {
+        Connection::create_native_widget_from_ptr(self, raw, size)
     }
 }

--- a/surfman/src/platform/android/connection.rs
+++ b/surfman/src/platform/android/connection.rs
@@ -7,7 +7,12 @@
 use crate::Error;
 use crate::GLApi;
 use super::device::{Adapter, Device, NativeDevice};
+use super::ffi::ANativeWindow;
 use super::surface::NativeWidget;
+
+use euclid::default::Size2D;
+
+use std::os::raw::c_void;
 
 #[cfg(feature = "sm-winit")]
 use winit::Window;
@@ -105,6 +110,13 @@ impl Connection {
     pub fn create_native_widget_from_winit_window(&self, _: &Window)
                                                   -> Result<NativeWidget, Error> {
         Err(Error::UnsupportedOnThisPlatform)
+    }
+
+    /// Create a native widget from a raw pointer
+    pub unsafe fn create_native_widget_from_ptr(&self, raw: *mut c_void, _size: Size2D<i32>) -> NativeWidget {
+        NativeWidget {
+            native_window: raw as *mut ANativeWindow,
+        }
     }
 }
 

--- a/surfman/src/platform/generic/multi/connection.rs
+++ b/surfman/src/platform/generic/multi/connection.rs
@@ -9,6 +9,10 @@ use crate::device::Device as DeviceInterface;
 use super::device::{Adapter, Device, NativeDevice};
 use super::surface::NativeWidget;
 
+use euclid::default::Size2D;
+
+use std::os::raw::c_void;
+
 #[cfg(feature = "sm-winit")]
 use winit::Window;
 
@@ -199,6 +203,18 @@ impl<Def, Alt> Connection<Def, Alt>
             }
         }
     }
+
+    /// Create a native widget from a raw pointer
+    pub unsafe fn create_native_widget_from_ptr(&self, raw: *mut c_void, size: Size2D<i32>) -> NativeWidget<Def, Alt> {
+        match *self {
+            Connection::Default(ref connection) => {
+                NativeWidget::Default(connection.create_native_widget_from_ptr(raw, size))
+            }
+            Connection::Alternate(ref connection) => {
+                NativeWidget::Alternate(connection.create_native_widget_from_ptr(raw, size))
+            }
+        }
+    }
 }
 
 impl<Def, Alt> ConnectionInterface for Connection<Def, Alt>
@@ -268,5 +284,10 @@ impl<Def, Alt> ConnectionInterface for Connection<Def, Alt>
     fn create_native_widget_from_winit_window(&self, window: &Window)
                                               -> Result<Self::NativeWidget, Error> {
         Connection::create_native_widget_from_winit_window(self, window)
+    }
+
+    #[inline]
+    unsafe fn create_native_widget_from_ptr(&self, raw: *mut c_void, size: Size2D<i32>) -> NativeWidget<Def, Alt> {
+        Connection::create_native_widget_from_ptr(self, raw, size)
     }
 }

--- a/surfman/src/platform/macos/cgl/connection.rs
+++ b/surfman/src/platform/macos/cgl/connection.rs
@@ -12,6 +12,10 @@ use crate::platform::macos::system::device::NativeDevice;
 use crate::platform::macos::system::surface::NativeWidget;
 use super::device::{Adapter, Device};
 
+use euclid::default::Size2D;
+
+use std::os::raw::c_void;
+
 #[cfg(feature = "sm-winit")]
 use winit::Window;
 
@@ -102,5 +106,10 @@ impl Connection {
     pub fn create_native_widget_from_winit_window(&self, window: &Window)
                                                   -> Result<NativeWidget, Error> {
         self.0.create_native_widget_from_winit_window(window)
+    }
+
+    /// Creates a native widget from a raw pointer
+    pub unsafe fn create_native_widget_from_ptr(&self, raw: *mut c_void, size: Size2D<i32>) -> NativeWidget {
+        self.0.create_native_widget_from_ptr(raw, size)
     }
 }

--- a/surfman/src/platform/macos/system/connection.rs
+++ b/surfman/src/platform/macos/system/connection.rs
@@ -16,7 +16,11 @@ use core_foundation::bundle::CFBundleGetInfoDictionary;
 use core_foundation::bundle::CFBundleGetMainBundle;
 use core_foundation::dictionary::{CFMutableDictionary, CFMutableDictionaryRef};
 use core_foundation::string::CFString;
+
+use euclid::default::Size2D;
+
 use std::str::FromStr;
+use std::os::raw::c_void;
 
 #[cfg(feature = "sm-winit")]
 use winit::Window;
@@ -132,6 +136,13 @@ impl Connection {
         }
         unsafe {
             Ok(NativeWidget { view: NSView(msg_send![ns_view, retain]) })
+        }
+    }
+
+    /// Create a native widget from a raw pointer
+    pub unsafe fn create_native_widget_from_ptr(&self, raw: *mut c_void, _size: Size2D<i32>) -> NativeWidget {
+        NativeWidget {
+            view: NSView(raw as id),
         }
     }
 }

--- a/surfman/src/platform/unix/generic/connection.rs
+++ b/surfman/src/platform/unix/generic/connection.rs
@@ -11,6 +11,8 @@ use crate::platform::generic::egl::ffi::EGL_PLATFORM_SURFACELESS_MESA;
 use super::device::{Adapter, Device, NativeDevice};
 use super::surface::NativeWidget;
 
+use euclid::default::Size2D;
+
 use std::os::raw::c_void;
 use std::sync::Arc;
 
@@ -145,6 +147,11 @@ impl Connection {
     pub fn create_native_widget_from_winit_window(&self, _: &Window)
                                                   -> Result<NativeWidget, Error> {
         Err(Error::IncompatibleNativeWidget)
+    }
+
+    /// Create a native widget from a raw pointer
+    pub unsafe fn create_native_widget_from_ptr(&self, _raw: *mut c_void, size: Size2D<i32>) -> NativeWidget {
+        NativeWidget
     }
 }
 

--- a/surfman/src/platform/unix/wayland/connection.rs
+++ b/surfman/src/platform/unix/wayland/connection.rs
@@ -179,6 +179,14 @@ impl Connection {
 
         Ok(NativeWidget { wayland_surface, size: window_size })
     }
+
+    /// Create a native widget from a raw pointer
+    pub unsafe fn create_native_widget_from_ptr(&self, raw: *mut c_void, size: Size2D<i32>) -> NativeWidget {
+        NativeWidget {
+            wayland_surface: raw as *mut wl_proxy,
+            size,
+        }
+    }
 }
 
 impl Drop for NativeConnectionWrapper {

--- a/surfman/src/platform/unix/x11/connection.rs
+++ b/surfman/src/platform/unix/x11/connection.rs
@@ -12,6 +12,8 @@ use crate::platform::unix::generic::device::Adapter;
 use super::device::{Device, NativeDevice};
 use super::surface::NativeWidget;
 
+use euclid::default::Size2D;
+
 use std::marker::PhantomData;
 use std::os::raw::c_void;
 use std::ptr;
@@ -206,6 +208,13 @@ impl Connection {
         match window.get_xlib_window() {
             Some(window) => Ok(NativeWidget { window }),
             None => Err(Error::IncompatibleNativeWidget),
+        }
+    }
+
+    /// Create a native widget from a raw pointer
+    pub unsafe fn create_native_widget_from_ptr(&self, raw: *mut c_void, _size: Size2D<i32>) -> NativeWidget {
+        NativeWidget {
+            window: std::mem::transmute(raw),
         }
     }
 }

--- a/surfman/src/platform/windows/angle/connection.rs
+++ b/surfman/src/platform/windows/angle/connection.rs
@@ -13,6 +13,10 @@ use crate::GLApi;
 use super::device::{Adapter, Device, NativeDevice, VendorPreference};
 use super::surface::NativeWidget;
 
+use euclid::default::Size2D;
+
+use std::os::raw::c_void;
+
 use winapi::shared::minwindef::UINT;
 use winapi::um::d3dcommon::{D3D_DRIVER_TYPE_UNKNOWN, D3D_DRIVER_TYPE_WARP};
 
@@ -121,7 +125,8 @@ impl Connection {
     /// Creates a native widget type from the given `winit` window.
     /// 
     /// This type can be later used to create surfaces that render to the window.
-    #[cfg(feature = "sm-winit")]
+    // This is not implemented for UWP
+    #[cfg(all(feature = "sm-winit", not(target_vendor = "uwp")))]
     #[inline]
     pub fn create_native_widget_from_winit_window(&self, window: &Window)
                                                   -> Result<NativeWidget, Error> {
@@ -130,6 +135,13 @@ impl Connection {
             Err(Error::IncompatibleNativeWidget)
         } else {
             Ok(NativeWidget { egl_native_window: hwnd })
+        }
+    }
+
+    /// Create a native widget from a raw pointer
+    pub unsafe fn create_native_widget_from_ptr(&self, raw: *mut c_void, _size: Size2D<i32>) -> NativeWidget {
+        NativeWidget {
+            egl_native_window: raw as EGLNativeWindowType,
         }
     }
 }

--- a/surfman/src/platform/windows/wgl/connection.rs
+++ b/surfman/src/platform/windows/wgl/connection.rs
@@ -9,6 +9,10 @@ use crate::GLApi;
 use super::device::{Adapter, Device, NativeDevice};
 use super::surface::NativeWidget;
 
+use euclid::default::Size2D;
+
+use std::os::raw::c_void;
+
 use winapi::shared::windef::HWND;
 
 #[cfg(feature = "sm-winit")]
@@ -116,6 +120,13 @@ impl Connection {
             Err(Error::IncompatibleNativeWidget)
         } else {
             Ok(NativeWidget { window_handle: hwnd })
+        }
+    }
+
+    /// Create a native widget from a raw pointer
+    pub unsafe fn create_native_widget_from_ptr(&self, raw: *mut c_void, _size: Size2D<i32>) -> NativeWidget {
+        NativeWidget {
+            window_handle: raw as HWND,
         }
     }
 }


### PR DESCRIPTION
This is needed in servo's C API, which gets the native widget as a `void*`.