### PR TITLE
Export NativeContext and NativeDevice

### DIFF
--- a/surfman/src/lib.rs
+++ b/surfman/src/lib.rs
@@ -23,16 +23,12 @@ extern crate log;
 extern crate objc;
 
 pub mod platform;
-pub use platform::default::connection::Connection;
-pub use platform::default::context::{Context, ContextDescriptor};
-pub use platform::default::device::{Adapter, Device};
+pub use platform::default::connection::{Connection, NativeConnection};
+pub use platform::default::context::{Context, ContextDescriptor, NativeContext};
+pub use platform::default::device::{Adapter, Device, NativeDevice};
 pub use platform::default::surface::{NativeWidget, Surface, SurfaceTexture};
 
 // TODO(pcwalton): Fill this in with other OS's.
-#[cfg(target_os = "android")]
-pub use platform::default::context::NativeContext;
-#[cfg(target_os = "android")]
-pub use platform::default::device::NativeDevice;
 #[cfg(target_os = "macos")]
 pub use platform::system::connection::Connection as SystemConnection;
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
At the moment we only export `Native*` on android, this exports them on all platforms.