### PR TITLE
Add a method to resize a widget-backed surface

### DIFF
--- a/surfman/src/device.rs
+++ b/surfman/src/device.rs
@@ -4,6 +4,7 @@
 
 use crate::{ContextAttributes, ContextID, Error, GLApi, SurfaceAccess, SurfaceInfo, SurfaceType};
 use crate::gl::types::{GLenum, GLuint};
+use euclid::default::Size2D;
 use super::connection::Connection as ConnectionInterface;
 
 use std::os::raw::c_void;
@@ -185,6 +186,10 @@ pub trait Device: Sized where Self::Connection: ConnectionInterface {
     /// The supplied context must match the context the surface was created with, or an
     /// `IncompatibleSurface` error is returned.
     fn present_surface(&self, context: &Self::Context, surface: &mut Self::Surface)
+                       -> Result<(), Error>;
+
+    /// Resizes a widget surface.
+    fn resize_surface(&self, context: &Self::Context, surface: &mut Self::Surface, size: Size2D<i32>)
                        -> Result<(), Error>;
 
     /// Returns various information about the surface, including the framebuffer object needed to

--- a/surfman/src/implementation/device.rs
+++ b/surfman/src/implementation/device.rs
@@ -7,6 +7,7 @@ use crate::connection::Connection as ConnectionInterface;
 use crate::device::Device as DeviceInterface;
 use crate::gl::types::{GLenum, GLuint};
 use crate::{ContextAttributes, ContextID, Error, GLApi, SurfaceAccess, SurfaceInfo, SurfaceType};
+use euclid::default::Size2D;
 use super::super::connection::Connection;
 use super::super::context::{Context, ContextDescriptor, NativeContext};
 use super::super::device::{Adapter, Device};
@@ -164,6 +165,12 @@ impl DeviceInterface for Device {
     fn present_surface(&self, context: &Self::Context, surface: &mut Self::Surface)
                        -> Result<(), Error> {
         Device::present_surface(self, context, surface)
+    }
+
+    #[inline]
+    fn resize_surface(&self, context: &Context, surface: &mut Surface, size: Size2D<i32>)
+                       -> Result<(), Error> {
+        Device::resize_surface(self, context, surface, size)
     }
 
     #[inline]

--- a/surfman/src/platform/android/surface.rs
+++ b/surfman/src/platform/android/surface.rs
@@ -288,6 +288,12 @@ impl Device {
         })
     }
 
+    /// Resizes a widget surface.
+    pub fn resize_surface(&self, context: &Context, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
+        surface.size = size;
+        Ok(())
+    }
+
     #[allow(non_snake_case)]
     unsafe fn create_egl_image(&self, _: &Context, hardware_buffer: *mut AHardwareBuffer)
                                -> EGLImageKHR {

--- a/surfman/src/platform/generic/egl/surface.rs
+++ b/surfman/src/platform/generic/egl/surface.rs
@@ -274,6 +274,13 @@ impl EGLBackedSurface {
         }
     }
 
+    pub(crate) fn native_window(&self) -> Result<*const c_void, Error> {
+        match self.objects {
+            EGLSurfaceObjects::TextureImage { .. } => Err(Error::NoWidgetAttached),
+            EGLSurfaceObjects::Window { native_window, .. } => Ok(native_window),
+        }
+    }
+
     pub(crate) fn unbind(&self, gl: &Gl, egl_display: EGLDisplay, egl_context: EGLContext) {
         // If we're current, we stay current, but with no surface attached.
         unsafe {

--- a/surfman/src/platform/generic/multi/device.rs
+++ b/surfman/src/platform/generic/multi/device.rs
@@ -7,6 +7,7 @@ use crate::connection::Connection as ConnectionInterface;
 use crate::context::ContextAttributes;
 use crate::device::Device as DeviceInterface;
 use crate::gl::types::{GLenum, GLuint};
+use euclid::default::Size2D;
 use super::connection::Connection;
 use super::context::{Context, ContextDescriptor, NativeContext};
 use super::surface::{NativeWidget, Surface, SurfaceTexture};
@@ -245,6 +246,12 @@ impl<Def, Alt> DeviceInterface for Device<Def, Alt>
     fn present_surface(&self, context: &Context<Def, Alt>, surface: &mut Surface<Def, Alt>)
                        -> Result<(), Error> {
         Device::present_surface(self, context, surface)
+    }
+
+    #[inline]
+    fn resize_surface(&self, context: &Context<Def, Alt>, surface: &mut Surface<Def, Alt>, size: Size2D<i32>)
+                       -> Result<(), Error> {
+        Device::resize_surface(self, context, surface, size)
     }
 
     #[inline]

--- a/surfman/src/platform/generic/multi/surface.rs
+++ b/surfman/src/platform/generic/multi/surface.rs
@@ -6,6 +6,7 @@ use crate::connection::Connection as ConnectionInterface;
 use crate::device::Device as DeviceInterface;
 use crate::gl::types::{GLenum, GLuint};
 use crate::{Error, SurfaceAccess, SurfaceInfo, SurfaceType};
+use euclid::default::Size2D;
 use super::context::Context;
 use super::device::Device;
 
@@ -242,6 +243,28 @@ impl<Def, Alt> Device<Def, Alt> where Def: DeviceInterface, Alt: DeviceInterface
                 match *surface {
                     Surface::Alternate(ref mut surface) => {
                         device.present_surface(context, surface)
+                    }
+                    _ => Err(Error::IncompatibleSurface),
+                }
+            }
+            _ => Err(Error::IncompatibleContext),
+        }
+    }
+
+    /// Resizes a widget surface.
+    pub fn resize_surface(&self, context: &Context<Def, Alt>, surface: &mut Surface<Def, Alt>, size: Size2D<i32>)
+                           -> Result<(), Error> {
+        match (self, context) {
+            (&Device::Default(ref device), &Context::Default(ref context)) => {
+                match *surface {
+                    Surface::Default(ref mut surface) => device.resize_surface(context, surface, size),
+                    _ => Err(Error::IncompatibleSurface),
+                }
+            }
+            (&Device::Alternate(ref device), &Context::Alternate(ref context)) => {
+                match *surface {
+                    Surface::Alternate(ref mut surface) => {
+                        device.resize_surface(context, surface, size)
                     }
                     _ => Err(Error::IncompatibleSurface),
                 }

--- a/surfman/src/platform/unix/generic/surface.rs
+++ b/surfman/src/platform/unix/generic/surface.rs
@@ -153,6 +153,11 @@ impl Device {
         surface.0.present(self.native_connection.egl_display, context.0.egl_context)
     }
 
+    /// Resizes a widget surface.
+    pub fn resize_surface(&self, context: &Context, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
+        todo!()
+    }
+
     /// Returns a pointer to the underlying surface data for reading or writing by the CPU.
     #[inline]
     pub fn lock_surface_data<'s>(&self, _: &'s mut Surface)

--- a/surfman/src/platform/unix/wayland/surface.rs
+++ b/surfman/src/platform/unix/wayland/surface.rs
@@ -189,6 +189,14 @@ impl Device {
         surface.0.present(self.native_connection.egl_display, context.0.egl_context)
     }
 
+    /// Resizes a widget surface.
+    pub fn resize_surface(&self, context: &Context, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
+        let wayland_egl_window = surface.0.native_window()? as *mut c_void as *mut wl_egl_window;
+	unsafe { (WAYLAND_EGL_HANDLE.wl_egl_window_resize)(wayland_egl_window, size.width, size.height, 0, 0) };
+	surface.0.size = size;
+	Ok(())
+    }
+
     /// Returns a pointer to the underlying surface data for reading or writing by the CPU.
     #[inline]
     pub fn lock_surface_data<'s>(&self, _: &'s mut Surface)

--- a/surfman/src/platform/unix/x11/surface.rs
+++ b/surfman/src/platform/unix/x11/surface.rs
@@ -186,6 +186,11 @@ impl Device {
         surface.0.present(self.native_connection.egl_display, context.0.egl_context)
     }
 
+    /// Resizes a widget surface.
+    pub fn resize_surface(&self, context: &Context, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
+        Ok(())
+    }
+
     /// Returns a pointer to the underlying surface data for reading or writing by the CPU.
     #[inline]
     pub fn lock_surface_data<'s>(&self, _: &'s mut Surface)

--- a/surfman/src/platform/windows/angle/surface.rs
+++ b/surfman/src/platform/windows/angle/surface.rs
@@ -454,6 +454,12 @@ impl Device {
         })
     }
 
+    /// Resizes a widget surface.
+    pub fn resize_surface(&self, context: &Context, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
+        surface.size = size;
+        Ok(())
+    }
+
     /// Returns various information about the surface, including the framebuffer object needed to
     /// render to this surface.
     /// 

--- a/surfman/src/platform/windows/wgl/surface.rs
+++ b/surfman/src/platform/windows/wgl/surface.rs
@@ -534,6 +534,12 @@ impl Device {
         }
     }
 
+    /// Resizes a widget surface.
+    pub fn resize_surface(&self, context: &Context, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
+        surface.size = size;
+        Ok(())
+    }
+
     /// Returns various information about the surface, including the framebuffer object needed to
     /// render to this surface.
     /// 


### PR DESCRIPTION
On some platforms (e.g. macos and wayland) widget-backed surfaces don't automatically resize when the widget is resized, so we need an API for that.