### PR TITLE
Remove build warnings

### DIFF
--- a/surfman/Cargo.toml
+++ b/surfman/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/pcwalton/surfman"
 build = "build.rs"
 
 [build-dependencies]
-gl_generator = "0.11"
+gl_generator = "0.13"
 
 [features]
 default = ["sm-winit"]

--- a/surfman/src/context.rs
+++ b/surfman/src/context.rs
@@ -2,6 +2,8 @@
 //
 //! Declarations common to all platform contexts.
 
+#![allow(unused_imports)]
+
 use crate::Gl;
 use crate::gl::types::GLuint;
 use crate::gl;
@@ -68,11 +70,12 @@ impl ContextAttributes {
 }
 
 #[cfg(target_os = "android")]
-pub(crate) fn current_context_uses_compatibility_profile(gl: &Gl) -> bool {
+pub(crate) fn current_context_uses_compatibility_profile(_gl: &Gl) -> bool {
     false
 }
 
 #[cfg(not(target_os = "android"))]
+#[allow(dead_code)]
 pub(crate) fn current_context_uses_compatibility_profile(gl: &Gl) -> bool {
     unsafe {
         // First, try `GL_CONTEXT_PROFILE_MASK`.
@@ -84,7 +87,6 @@ pub(crate) fn current_context_uses_compatibility_profile(gl: &Gl) -> bool {
         }
 
         // Second, look for the `GL_ARB_compatibility` extension.
-        let mut compatibility_profile = false;
         let mut num_extensions = 0;
         gl.GetIntegerv(gl::NUM_EXTENSIONS, &mut num_extensions);
         if gl.GetError() == gl::NO_ERROR {

--- a/surfman/src/info.rs
+++ b/surfman/src/info.rs
@@ -36,6 +36,7 @@ impl GLVersion {
         GLVersion { major, minor }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn current(gl: &Gl) -> GLVersion {
         unsafe {
             let version_string = gl.GetString(gl::VERSION) as *const c_char;

--- a/surfman/src/platform/android/context.rs
+++ b/surfman/src/platform/android/context.rs
@@ -81,7 +81,6 @@ impl Device {
     pub fn create_context(&mut self, descriptor: &ContextDescriptor) -> Result<Context, Error> {
         let mut next_context_id = CREATE_CONTEXT_MUTEX.lock().unwrap();
 
-        let egl_config = self.context_descriptor_to_egl_config(descriptor);
         let egl_display = self.egl_display;
 
         unsafe {

--- a/surfman/src/platform/android/surface.rs
+++ b/surfman/src/platform/android/surface.rs
@@ -289,7 +289,7 @@ impl Device {
     }
 
     /// Resizes a widget surface.
-    pub fn resize_surface(&self, context: &Context, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
+    pub fn resize_surface(&self, _context: &Context, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
         surface.size = size;
         Ok(())
     }

--- a/surfman/src/platform/generic/egl/context.rs
+++ b/surfman/src/platform/generic/egl/context.rs
@@ -5,18 +5,16 @@
 use crate::context::{self, CREATE_CONTEXT_MUTEX};
 use crate::egl::types::{EGLConfig, EGLContext, EGLDisplay, EGLSurface, EGLint};
 use crate::egl;
-use crate::gl::types::GLuint;
-use crate::gl;
 use crate::surface::Framebuffer;
 use crate::{ContextAttributeFlags, ContextAttributes, ContextID, Error, GLApi, GLVersion};
 use crate::{Gl, SurfaceInfo};
 use super::device::EGL_FUNCTIONS;
 use super::error::ToWindowingApiError;
 use super::ffi::{EGL_CONTEXT_MINOR_VERSION_KHR, EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT};
-use super::ffi::{EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT, EGL_CONTEXT_OPENGL_PROFILE_MASK};
+use super::ffi::EGL_CONTEXT_OPENGL_PROFILE_MASK;
 use super::surface::{EGLBackedSurface, ExternalEGLSurfaces};
 
-use std::ffi::{CStr, CString};
+use std::ffi::CString;
 use std::mem;
 use std::os::raw::{c_char, c_void};
 use std::ptr;

--- a/surfman/src/platform/generic/egl/mod.rs
+++ b/surfman/src/platform/generic/egl/mod.rs
@@ -2,6 +2,8 @@
 //
 //! Functionality common to EGL-based backends.
 
+#![allow(dead_code)]
+
 pub(crate) mod context;
 pub(crate) mod device;
 pub(crate) mod error;

--- a/surfman/src/platform/macos/cgl/surface.rs
+++ b/surfman/src/platform/macos/cgl/surface.rs
@@ -123,7 +123,7 @@ impl Device {
                     if texture_object != 0 {
                         gl.DeleteTextures(1, &mut texture_object);
                     }
-                    self.0.destroy_surface(&mut system_surface);
+                    let _ = self.0.destroy_surface(&mut system_surface);
                     // TODO: convert the GL error into a surfman error?
                     return Err(Error::SurfaceCreationFailed(WindowingApiError::Failed));
                 }

--- a/surfman/src/platform/unix/default.rs
+++ b/surfman/src/platform/unix/default.rs
@@ -15,6 +15,7 @@ pub mod connection {
     /// Either a Wayland or an X11 display server connection.
     pub type Connection = MultiConnection<HWDevice, SWDevice>;
 
+    /// Either a Wayland or an X11 native connection
     pub type NativeConnection = MultiNativeConnection<HWDevice, SWDevice>;
 }
 
@@ -53,6 +54,7 @@ pub mod context {
     /// These are local to a device.
     pub type ContextDescriptor = MultiContextDescriptor<HWDevice, SWDevice>;
 
+    /// Either a Wayland or an X11 native context
     pub type NativeContext = MultiNativeContext<HWDevice, SWDevice>;
 }
 
@@ -78,6 +80,7 @@ pub mod device {
     /// Devices contain most of the relevant surface management methods.
     pub type Device = MultiDevice<HWDevice, SWDevice>;
 
+    /// Either a Wayland or an X11 native device
     pub type NativeDevice = MultiNativeDevice<HWDevice, SWDevice>;
 }
 

--- a/surfman/src/platform/unix/generic/connection.rs
+++ b/surfman/src/platform/unix/generic/connection.rs
@@ -150,7 +150,7 @@ impl Connection {
     }
 
     /// Create a native widget from a raw pointer
-    pub unsafe fn create_native_widget_from_ptr(&self, _raw: *mut c_void, size: Size2D<i32>) -> NativeWidget {
+    pub unsafe fn create_native_widget_from_ptr(&self, _raw: *mut c_void, _size: Size2D<i32>) -> NativeWidget {
         NativeWidget
     }
 }

--- a/surfman/src/platform/unix/generic/surface.rs
+++ b/surfman/src/platform/unix/generic/surface.rs
@@ -154,8 +154,9 @@ impl Device {
     }
 
     /// Resizes a widget surface.
-    pub fn resize_surface(&self, context: &Context, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
-        todo!()
+    pub fn resize_surface(&self, _context: &Context, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
+        surface.0.size = size;
+	Ok(())
     }
 
     /// Returns a pointer to the underlying surface data for reading or writing by the CPU.

--- a/surfman/src/platform/unix/wayland/surface.rs
+++ b/surfman/src/platform/unix/wayland/surface.rs
@@ -190,7 +190,7 @@ impl Device {
     }
 
     /// Resizes a widget surface.
-    pub fn resize_surface(&self, context: &Context, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
+    pub fn resize_surface(&self, _context: &Context, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
         let wayland_egl_window = surface.0.native_window()? as *mut c_void as *mut wl_egl_window;
 	unsafe { (WAYLAND_EGL_HANDLE.wl_egl_window_resize)(wayland_egl_window, size.width, size.height, 0, 0) };
 	surface.0.size = size;

--- a/surfman/src/platform/unix/x11/surface.rs
+++ b/surfman/src/platform/unix/x11/surface.rs
@@ -187,7 +187,8 @@ impl Device {
     }
 
     /// Resizes a widget surface.
-    pub fn resize_surface(&self, context: &Context, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
+    pub fn resize_surface(&self, _context: &Context, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
+        surface.0.size = size;
         Ok(())
     }
 

--- a/surfman/src/platform/windows/angle/surface.rs
+++ b/surfman/src/platform/windows/angle/surface.rs
@@ -25,13 +25,11 @@ use std::os::raw::c_void;
 use std::ptr;
 use std::thread;
 use winapi::shared::dxgi::IDXGIKeyedMutex;
-use winapi::shared::windef::{HWND, RECT};
 use winapi::shared::winerror::S_OK;
 use winapi::um::d3d11;
 use winapi::um::handleapi::INVALID_HANDLE_VALUE;
 use winapi::um::winbase::INFINITE;
 use winapi::um::winnt::HANDLE;
-use winapi::um::winuser;
 use wio::com::ComPtr;
 
 const SURFACE_GL_TEXTURE_TARGET: GLenum = gl::TEXTURE_2D;
@@ -463,7 +461,7 @@ impl Device {
     }
 
     /// Resizes a widget surface.
-    pub fn resize_surface(&self, context: &Context, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
+    pub fn resize_surface(&self, _context: &Context, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
         surface.size = size;
         Ok(())
     }

--- a/surfman/src/platform/windows/wgl/surface.rs
+++ b/surfman/src/platform/windows/wgl/surface.rs
@@ -535,7 +535,7 @@ impl Device {
     }
 
     /// Resizes a widget surface.
-    pub fn resize_surface(&self, context: &Context, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
+    pub fn resize_surface(&self, _scontext: &Context, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
         surface.size = size;
         Ok(())
     }


### PR DESCRIPTION
This gets rid of the build warnings, mostly unused imports and dead code, some of which are caused by building for different OSs.