### PR TITLE
Support creating an adapter from a DXGI adapter

### DIFF
--- a/surfman/src/platform/windows/angle/connection.rs
+++ b/surfman/src/platform/windows/angle/connection.rs
@@ -22,7 +22,7 @@ use winapi::um::d3dcommon::{D3D_DRIVER_TYPE_UNKNOWN, D3D_DRIVER_TYPE_WARP};
 
 #[cfg(feature = "sm-winit")]
 use winit::Window;
-#[cfg(feature = "sm-winit")]
+#[cfg(all(feature = "sm-winit", not(target_vendor = "uwp")))]
 use winit::os::windows::WindowExt;
 
 const INTEL_PCI_ID: UINT = 0x8086;
@@ -125,7 +125,6 @@ impl Connection {
     /// Creates a native widget type from the given `winit` window.
     /// 
     /// This type can be later used to create surfaces that render to the window.
-    // This is not implemented for UWP
     #[cfg(all(feature = "sm-winit", not(target_vendor = "uwp")))]
     #[inline]
     pub fn create_native_widget_from_winit_window(&self, window: &Window)
@@ -136,6 +135,15 @@ impl Connection {
         } else {
             Ok(NativeWidget { egl_native_window: hwnd })
         }
+    }
+
+    /// Creates a native widget type from the given `winit` window.
+    /// This is unsupported on UWP.
+    #[cfg(all(feature = "sm-winit", target_vendor = "uwp"))]
+    #[inline]
+    pub fn create_native_widget_from_winit_window(&self, _window: &Window)
+                                                  -> Result<NativeWidget, Error> {
+        Err(Error::IncompatibleNativeWidget)
     }
 
     /// Create a native widget from a raw pointer

--- a/surfman/src/platform/windows/angle/device.rs
+++ b/surfman/src/platform/windows/angle/device.rs
@@ -19,7 +19,7 @@ use winapi::shared::dxgi::{self, IDXGIAdapter, IDXGIDevice, IDXGIFactory1};
 use winapi::shared::minwindef::UINT;
 use winapi::shared::winerror::{self, S_OK};
 use winapi::um::d3d11::{D3D11CreateDevice, D3D11_SDK_VERSION, ID3D11Device};
-use winapi::um::d3dcommon::{D3D_DRIVER_TYPE, D3D_FEATURE_LEVEL_9_3};
+use winapi::um::d3dcommon::{D3D_DRIVER_TYPE_UNKNOWN, D3D_DRIVER_TYPE, D3D_FEATURE_LEVEL_9_3};
 use wio::com::ComPtr;
 
 thread_local! {
@@ -136,6 +136,14 @@ impl Adapter {
             let dxgi_adapter = ComPtr::from_raw(dxgi_adapter);
 
             Ok(Adapter { dxgi_adapter, d3d_driver_type })
+        }
+    }
+
+    /// Create an Adapter instance wrapping an existing DXGI adapter.
+    pub fn from_dxgi_adapter(adapter: ComPtr<IDXGIAdapter>) -> Adapter {
+        Adapter {
+            dxgi_adapter: adapter,
+            d3d_driver_type: D3D_DRIVER_TYPE_UNKNOWN,
         }
     }
 }


### PR DESCRIPTION
This is important in cases where an external caller has strict requirements about which adapter should be used when creating a surfman device.