### PR TITLE
Allow creating a SurfaceTexture from a D3D11 texture

### DIFF
--- a/surfman/src/platform/windows/angle/surface.rs
+++ b/surfman/src/platform/windows/angle/surface.rs
@@ -325,7 +325,25 @@ impl Device {
                 } else {
                     None
                 };
+                self.create_surface_texture_from_local_surface(
+                    context,
+                    surface,
+                    local_egl_surface,
+                    local_keyed_mutex,
+                )
+            }
+        })
+    }
 
+    fn create_surface_texture_from_local_surface(
+        &self,
+        context: &Context,
+        surface: Surface,
+        local_egl_surface: EGLSurface,
+        local_keyed_mutex: Option<ComPtr<IDXGIKeyedMutex>>,
+    ) -> Result<SurfaceTexture, (Error, Surface)> {
+        EGL_FUNCTIONS.with(|egl| {
+            unsafe {
                 let _guard = self.temporarily_make_context_current(context);
 
                 GL_FUNCTIONS.with(|gl| {
@@ -366,6 +384,23 @@ impl Device {
                 })
             }
         })
+    }
+
+    /// Given a D3D11 texture, create a surface texture that wraps that texture. This method is unsafe
+    /// in that the resulting surface is only valid on the current thread.
+    pub unsafe fn create_surface_texture_from_texture(
+        &mut self,
+        context: &mut Context,
+        size: &Size2D<i32>,
+        texture: *mut d3d11::ID3D11Texture2D
+    ) -> Result<SurfaceTexture, Error> {
+        let surface = self.create_pbuffer_surface(context, size, Some(texture))?;
+        let local_egl_surface = surface.egl_surface;
+        self.create_surface_texture_from_local_surface(context, surface, local_egl_surface, None)
+            .map_err(|(err, mut surface)| {
+                let _ = self.destroy_surface(context, &mut surface);
+                err
+            })
     }
 
     /// Destroys a surface.

--- a/surfman/src/platform/windows/angle/surface.rs
+++ b/surfman/src/platform/windows/angle/surface.rs
@@ -387,7 +387,8 @@ impl Device {
     }
 
     /// Given a D3D11 texture, create a surface texture that wraps that texture. This method is unsafe
-    /// in that the resulting surface is only valid on the current thread.
+    /// in that the resulting surface is only valid on the current thread, for the lifetime of `texture`.
+    /// It is the caller's responsibility to ensure that `texture` is not freed while the `SurfaceTexture` is live.
     pub unsafe fn create_surface_texture_from_texture(
         &mut self,
         context: &mut Context,


### PR DESCRIPTION
For webxr layer management on UWP, life is simpler if we can get surfman to create a `SurfaceTexture` directly from a D3D11 texture. We can't go via a surface annoyingly, since we want the `SurfaceTexture` to be created directly from the EGL pbuffer, not going via `eglCreatePbufferFromClientBuffer`.