### PR TITLE
Constrain width to a multiple of 4 when resizing surface on macOS 

### DIFF
--- a/surfman/src/platform/macos/system/surface.rs
+++ b/surfman/src/platform/macos/system/surface.rs
@@ -229,7 +229,14 @@ impl Device {
     }
 
     /// Resizes a widget surface
-    pub fn resize_surface(&self, surface: &mut Surface, size: Size2D<i32>) -> Result<(), Error> {
+    pub fn resize_surface(&self, surface: &mut Surface, mut size: Size2D<i32>) -> Result<(), Error> {
+        // The surface will not appear if its width is not a multiple of 4 (i.e. stride is a
+        // multiple of 16 bytes). Enforce this.
+        let width = size.width as i32;
+        if width % 4 != 0 {
+            size.width = width + 4 - width % 4;
+        }
+
         let view_info = match surface.view_info {
             None => return Err(Error::NoWidgetAttached),
             Some(ref mut view_info) => view_info,


### PR DESCRIPTION
It looks like `create_surface` constrains the width to a multiple of 4, but `resize_surface` does not. This was causing the behavior pictured below when resizing on macOS.

![resize-artifacts](https://user-images.githubusercontent.com/1789/87855103-52bd1700-c8d3-11ea-9771-1d82a1623f78.gif)