### PR TITLE
Fix Hang on Drop HiddenWindow on Windows

### DIFF
--- a/surfman/src/platform/windows/wgl/device.rs
+++ b/surfman/src/platform/windows/wgl/device.rs
@@ -255,7 +255,7 @@ pub(crate) struct DCGuard<'a> {
 impl Drop for HiddenWindow {
     fn drop(&mut self) {
         unsafe {
-            winuser::SendMessageA(self.window, WM_CLOSE, 0, 0);
+            winuser::PostMessageA(self.window, WM_CLOSE, 0, 0);
             if let Some(join_handle) = self.join_handle.take() {
                 drop(join_handle.join());
             }


### PR DESCRIPTION
As mentioned in #194 , dropping Device hangs on Windows because the HiddenWindow waits for a close message that never enters the queue.

Easiest fix is to replace SendMessage with PostMessage in the drop for HiddenWindow. This queues the message and returns immediately. Since we wait for the thread to finish after sending the close message, there should not be any problems using this method compared to SendMessage.

Fixes #194 