### PR TITLE
Don't depend on winit by default

### DIFF
--- a/surfman/Cargo.toml
+++ b/surfman/Cargo.toml
@@ -17,7 +17,7 @@ gl_generator = "0.14"
 cfg_aliases = "0.1.0"
 
 [features]
-default = ["sm-winit"]
+default = []
 sm-angle = []
 sm-angle-builtin = ["mozangle"]
 sm-angle-default = ["sm-angle"]


### PR DESCRIPTION
I don't think it's needed here. Adding a feature is always easier for consumers than removing one.
Related to #205