### PR TITLE
Fixed build errors due to winit v0.23.

### DIFF
--- a/surfman/Cargo.toml
+++ b/surfman/Cargo.toml
@@ -44,7 +44,7 @@ version = "0.1"
 optional = true
 
 [dependencies.winit]
-version = "<0.19.4" # 0.19.4 causes build errors https://github.com/rust-windowing/winit/pull/1105
+version = "0.23"
 optional = true
 
 [dependencies.raw-window-handle]

--- a/surfman/src/connection.rs
+++ b/surfman/src/connection.rs
@@ -10,7 +10,7 @@ use euclid::default::Size2D;
 use std::os::raw::c_void;
 
 #[cfg(feature = "sm-winit")]
-use winit::Window;
+use winit::window::Window;
 
 /// Methods relating to display server connections.
 pub trait Connection: Sized {

--- a/surfman/src/implementation/connection.rs
+++ b/surfman/src/implementation/connection.rs
@@ -15,7 +15,7 @@ use euclid::default::Size2D;
 use std::os::raw::c_void;
 
 #[cfg(feature = "sm-winit")]
-use winit::Window;
+use winit::window::Window;
 
 #[deny(unconditional_recursion)]
 impl ConnectionInterface for Connection {

--- a/surfman/src/platform/android/connection.rs
+++ b/surfman/src/platform/android/connection.rs
@@ -15,7 +15,7 @@ use euclid::default::Size2D;
 use std::os::raw::c_void;
 
 #[cfg(feature = "sm-winit")]
-use winit::Window;
+use winit::window::Window;
 
 /// A connection to the display server.
 #[derive(Clone)]

--- a/surfman/src/platform/generic/multi/connection.rs
+++ b/surfman/src/platform/generic/multi/connection.rs
@@ -14,7 +14,7 @@ use euclid::default::Size2D;
 use std::os::raw::c_void;
 
 #[cfg(feature = "sm-winit")]
-use winit::Window;
+use winit::window::Window;
 
 /// A connection to the display server.
 pub enum Connection<Def, Alt> where Def: DeviceInterface,

--- a/surfman/src/platform/macos/cgl/connection.rs
+++ b/surfman/src/platform/macos/cgl/connection.rs
@@ -22,7 +22,7 @@ use crate::platform::macos::system::surface::NSView;
 use cocoa::base::id;
 
 #[cfg(feature = "sm-winit")]
-use winit::Window;
+use winit::window::Window;
 
 pub use crate::platform::macos::system::connection::NativeConnection;
 

--- a/surfman/src/platform/macos/system/connection.rs
+++ b/surfman/src/platform/macos/system/connection.rs
@@ -23,7 +23,7 @@ use std::str::FromStr;
 use std::os::raw::c_void;
 
 #[cfg(feature = "sm-winit")]
-use winit::Window;
+use winit::window::Window;
 #[cfg(feature = "sm-winit")]
 use winit::os::macos::WindowExt;
 

--- a/surfman/src/platform/unix/generic/connection.rs
+++ b/surfman/src/platform/unix/generic/connection.rs
@@ -17,7 +17,7 @@ use std::os::raw::c_void;
 use std::sync::Arc;
 
 #[cfg(feature = "sm-winit")]
-use winit::Window;
+use winit::window::Window;
 
 /// A no-op connection.
 #[derive(Clone)]

--- a/surfman/src/platform/unix/wayland/connection.rs
+++ b/surfman/src/platform/unix/wayland/connection.rs
@@ -18,9 +18,10 @@ use std::sync::Arc;
 use wayland_sys::client::{WAYLAND_CLIENT_HANDLE, wl_display, wl_proxy};
 
 #[cfg(feature = "sm-winit")]
-use winit::Window;
+use winit::window::Window;
 #[cfg(feature = "sm-winit")]
-use winit::os::unix::WindowExt;
+// use winit::os::unix::WindowExt;
+use winit::platform::unix::WindowExtUnix;
 
 /// A connection to the Wayland server.
 #[derive(Clone)]
@@ -149,7 +150,7 @@ impl Connection {
     #[cfg(feature = "sm-winit")]
     pub fn from_winit_window(window: &Window) -> Result<Connection, Error> {
         unsafe {
-            let wayland_display = match window.get_wayland_display() {
+            let wayland_display = match window.wayland_display() {
                 Some(wayland_display) => wayland_display as *mut wl_display,
                 None => return Err(Error::IncompatibleWinitWindow),
             };
@@ -163,7 +164,7 @@ impl Connection {
     #[cfg(feature = "sm-winit")]
     pub fn create_native_widget_from_winit_window(&self, window: &Window)
                                                   -> Result<NativeWidget, Error> {
-        let wayland_surface = match window.get_wayland_surface() {
+        let wayland_surface = match window.wayland_surface() {
             Some(wayland_surface) => wayland_surface as *mut wl_proxy,
             None => return Err(Error::IncompatibleNativeWidget),
         };
@@ -173,8 +174,8 @@ impl Connection {
         // when actually displayed. (The user might move it somewhere else later, of course.)
         //
         // FIXME(pcwalton): Is it true that the window will go the primary monitor first?
-        let hidpi_factor = window.get_primary_monitor().get_hidpi_factor();
-        let window_size = window.get_inner_size().unwrap().to_physical(hidpi_factor);
+        // let hidpi_factor = window.primary_monitor().unwrap().scale_factor();
+        let window_size = window.inner_size();
         let window_size = Size2D::new(window_size.width as i32, window_size.height as i32);
 
         Ok(NativeWidget { wayland_surface, size: window_size })

--- a/surfman/src/platform/unix/x11/connection.rs
+++ b/surfman/src/platform/unix/x11/connection.rs
@@ -21,9 +21,10 @@ use std::sync::Arc;
 use x11::xlib::{Display, XCloseDisplay, XInitThreads, XLockDisplay, XOpenDisplay, XUnlockDisplay};
 
 #[cfg(feature = "sm-winit")]
-use winit::Window;
+use winit::window::Window;
 #[cfg(feature = "sm-winit")]
-use winit::os::unix::WindowExt;
+//use winit::os::unix::WindowExt;
+use winit::platform::unix::WindowExtUnix;
 
 lazy_static! {
     static ref X_THREADS_INIT: () = {
@@ -192,7 +193,7 @@ impl Connection {
     /// Opens the display connection corresponding to the given `winit` window.
     #[cfg(feature = "sm-winit")]
     pub fn from_winit_window(window: &Window) -> Result<Connection, Error> {
-        if let Some(display) = window.get_xlib_display() {
+        if let Some(display) = window.xlib_display() {
             Connection::from_x11_display(display as *mut Display, false)
         } else {
             Err(Error::IncompatibleWinitWindow)
@@ -205,7 +206,7 @@ impl Connection {
     #[cfg(feature = "sm-winit")]
     pub fn create_native_widget_from_winit_window(&self, window: &Window)
                                                   -> Result<NativeWidget, Error> {
-        match window.get_xlib_window() {
+        match window.xlib_window() {
             Some(window) => Ok(NativeWidget { window }),
             None => Err(Error::IncompatibleNativeWidget),
         }

--- a/surfman/src/platform/windows/angle/connection.rs
+++ b/surfman/src/platform/windows/angle/connection.rs
@@ -21,7 +21,7 @@ use winapi::shared::minwindef::UINT;
 use winapi::um::d3dcommon::{D3D_DRIVER_TYPE_UNKNOWN, D3D_DRIVER_TYPE_WARP};
 
 #[cfg(feature = "sm-winit")]
-use winit::Window;
+use winit::window::Window;
 #[cfg(all(feature = "sm-winit", not(target_vendor = "uwp")))]
 use winit::os::windows::WindowExt;
 

--- a/surfman/src/platform/windows/wgl/connection.rs
+++ b/surfman/src/platform/windows/wgl/connection.rs
@@ -16,7 +16,7 @@ use std::os::raw::c_void;
 use winapi::shared::windef::HWND;
 
 #[cfg(feature = "sm-winit")]
-use winit::Window;
+use winit::window::Window;
 #[cfg(feature = "sm-winit")]
 use winit::os::windows::WindowExt;
 


### PR DESCRIPTION
Winit 0.23 fixes a few run time errors when compiling with rustc 1.48. It may be a good idea to move to this version of winit.