### PR TITLE
Don't panic if CARGO_CFG_TARGET_FAMILY isn't set

### DIFF
--- a/surfman/build.rs
+++ b/surfman/build.rs
@@ -30,13 +30,13 @@ fn main() {
     }
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    let target_family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+    let target_family = env::var("CARGO_CFG_TARGET_FAMILY").ok();
     let dest = PathBuf::from(&env::var("OUT_DIR").unwrap());
 
     // Generate EGL bindings.
     if target_os == "android"
         || (target_os == "windows" && cfg!(feature = "sm-angle"))
-        || target_family == "unix"
+        || target_family.as_ref().map_or(false, |f| f == "unix")
     {
         let mut file = File::create(&dest.join("egl_bindings.rs")).unwrap();
         let registry = Registry::new(Api::Egl, (1, 5), Profile::Core, Fallbacks::All, []);


### PR DESCRIPTION
The `CARGO_CFG_TARGET_FAMILY` environment variable isn't defined for non-unix-non-windows platforms.

For context, I'm trying to add support for my custom platform. While I'm obviously not going to try upstream this custom platform, the change in this PR looks positive to me.

