### PR TITLE
Fix #232: android: avoid making EGLContext current without draw/read surfaces when creating window surface.

### DIFF
--- a/surfman/Cargo.toml
+++ b/surfman/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surfman"
 license = "MIT / Apache-2.0"
 edition = "2018"
-version = "0.4.2"
+version = "0.4.3"
 authors = [
     "Patrick Walton <pcwalton@mimiga.net>",
     "Emilio Cobos Álvarez <emilio@crisal.io>",

--- a/surfman/src/platform/android/context.rs
+++ b/surfman/src/platform/android/context.rs
@@ -316,11 +316,11 @@ impl Device {
         context::get_proc_address(symbol_name)
     }
 
-    pub(crate) fn context_descriptor_to_egl_config(
+    pub(crate) fn context_to_egl_config(
         &self,
-        context_descriptor: &ContextDescriptor,
+        context: &Context,
     ) -> EGLConfig {
-        unsafe { context::egl_config_from_id(self.egl_display, context_descriptor.egl_config_id) }
+        unsafe { context::egl_config_from_id(self.egl_display, context::get_context_attr(self.egl_display, context.egl_context, egl::CONFIG_ID as EGLint)) }
     }
 
     pub(crate) fn temporarily_make_context_current(

--- a/surfman/src/platform/android/surface.rs
+++ b/surfman/src/platform/android/surface.rs
@@ -212,13 +212,10 @@ impl Device {
         let width = ANativeWindow_getWidth(native_window);
         let height = ANativeWindow_getHeight(native_window);
 
-        let context_descriptor = self.context_descriptor(context);
-        let egl_config = self.context_descriptor_to_egl_config(&context_descriptor);
-
         EGL_FUNCTIONS.with(|egl| {
             let egl_surface = egl.CreateWindowSurface(
                 self.egl_display,
-                egl_config,
+                self.context_to_egl_config(context),
                 native_window as *const c_void,
                 ptr::null(),
             );


### PR DESCRIPTION
This change avoids making the EGLContext current on Android when creating the window surface. The EGLContext implementation provided by the Android Emulator (and by the "cuttlefish" Android board when running in `crosvm`) doesn't support surfaceless contexts which causes making the context current fails in those environments, resulting in a crash later on when we try to use `glGetString`. It's easily possible to get the EGLConfig needed to create the window surface without making the context current, and that's what this change does.

This change has been tested with the winit/ndk integration on the Android Emulator running Android 11 QPR2 on x86_64, and on a Samsung Galaxy Tab S6 (Qualcomm SoC) also running Android 11.