### PR TITLE
CI: Update the environment to `ubuntu-20.04`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,17 +11,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-16.04, windows-latest]
+        os: [macos-latest, ubuntu-20.04, windows-latest]
         rust: [nightly-2020-09-30, stable]
         features: ["", "--features sm-winit"]
         target: ["default"]
         include:
           # rust nightly
-          - os: ubuntu-16.04
+          - os: ubuntu-20.04
             features: "--features sm-wayland-default"
             rust: nightly-2020-09-30
             target: "default"
-          - os: ubuntu-16.04
+          - os: ubuntu-20.04
             target: "arm-linux-androideabi"
             rust: nightly-2020-09-30
           - os: windows-latest
@@ -36,11 +36,11 @@ jobs:
             target: "aarch64-pc-windows-msvc"
             rust: nightly-2020-09-30
           # rust stable
-          - os: ubuntu-16.04
+          - os: ubuntu-20.04
             features: "--features sm-wayland-default"
             rust: stable
             target: "default"
-          - os: ubuntu-16.04
+          - os: ubuntu-20.04
             target: "arm-linux-androideabi"
             rust: stable
           - os: windows-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,10 +63,8 @@ jobs:
     - name: Install deps on linux
       if: startsWith(matrix.os, 'ubuntu')
       run: |
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt update
-        sudo apt install gcc-4.8 g++-4.8 libxxf86vm-dev libosmesa6-dev gcc-arm-linux-androideabi libgles2-mesa-dev -y
-        export CXX=g++-4.8
+        sudo apt install gcc libxxf86vm-dev libosmesa6-dev libgles2-mesa-dev -y
     - name: Install rust
       uses: actions-rs/toolchain@v1
       with:


### PR DESCRIPTION
The Ubuntu 16.04 environment of GitHub Actions, which is currently used by our CI workflows, has been [retired][1] last month. This PR updates our CI workflows to use [the Ubuntu 20.04 environment][2].

[1]: https://github.com/actions/virtual-environments/issues/3287
[2]: https://github.com/actions/virtual-environments/blob/e4546d3d537dea790051af3fa7e04c0fc0809bac/images/linux/Ubuntu2004-README.md