### PR TITLE
Update euclid to 0.22 and bump version

### DIFF
--- a/android-example/rust/Cargo.toml
+++ b/android-example/rust/Cargo.toml
@@ -20,7 +20,7 @@ jni = "0.13"
 log = "0.4"
 
 [dependencies.euclid]
-version = "0.20"
+version = "0.22"
 features = []
 
 [dependencies.surfman]

--- a/surfman/Cargo.toml
+++ b/surfman/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surfman"
 license = "MIT / Apache-2.0"
 edition = "2018"
-version = "0.4.4"
+version = "0.5.0"
 authors = [
     "Patrick Walton <pcwalton@mimiga.net>",
     "Emilio Cobos Álvarez <emilio@crisal.io>",
@@ -36,7 +36,7 @@ log = "0.4"
 parking_lot = "0.10.2"
 
 [dependencies.euclid]
-version = "0.20"
+version = "0.22"
 features = []
 
 [dependencies.osmesa-sys]


### PR DESCRIPTION
This is a rebase of the original change at #234. Original message from @Bryce-MW:

> Updating Euclid is a breaking change which is why I bumped the version. https://github.com/servo/surfman/pull/222 and https://github.com/servo/surfman/pull/201 are not for the latest version of this repository and should be closed.
> 
> I was unable to build the android test so I don't know how well that works but no other changes were needed.
>
> This is part of my effort to update the version of webrender used by Servo. I have made https://github.com/servo/servo/issues/28585 to keep track.

Signed-off-by: Bryce Wilson <bryce@brycemw.ca>