### PR TITLE
Fix linux example to work with winit 0.24

### DIFF
--- a/surfman/examples/chaos_game.rs
+++ b/surfman/examples/chaos_game.rs
@@ -5,9 +5,10 @@
 use euclid::default::Point2D;
 use rand::{self, Rng};
 use surfman::{SurfaceAccess, SurfaceType};
-use winit::dpi::PhysicalSize;
-use winit::{DeviceEvent, Event, EventsLoop, KeyboardInput, VirtualKeyCode};
-use winit::{WindowBuilder, WindowEvent};
+use winit::dpi::{LogicalSize, PhysicalSize};
+use winit::event::{DeviceEvent, Event, WindowEvent, KeyboardInput, VirtualKeyCode};
+use winit::event_loop::{ControlFlow, EventLoop};
+use winit::window::WindowBuilder;
 
 #[cfg(target_os = "macos")]
 use surfman::SystemConnection;
@@ -38,15 +39,18 @@ fn main() {
     let adapter = connection.create_adapter().unwrap();
     let mut device = connection.create_device(&adapter).unwrap();
 
-    let mut event_loop = EventsLoop::new();
-    let dpi = event_loop.get_primary_monitor().get_scale_factor();
-    let logical_size = PhysicalSize::new(WINDOW_WIDTH as f64, WINDOW_HEIGHT as f64).to_logical(dpi);
+    let event_loop = EventLoop::new();
+    let dpi = event_loop.primary_monitor().unwrap().scale_factor();
+    let logical_size =
+        PhysicalSize::new(WINDOW_WIDTH, WINDOW_HEIGHT)
+        .to_logical::<f64>(dpi);
     let window = WindowBuilder::new()
         .with_title("Chaos game example")
-        .with_dimensions(logical_size)
+        .with_inner_size(logical_size)
         .build(&event_loop)
         .unwrap();
-    window.show();
+
+    window.set_visible(true);
 
     let native_widget = connection
         .create_native_widget_from_winit_window(&window)
@@ -61,24 +65,10 @@ fn main() {
     let mut point = Point2D::new(WINDOW_WIDTH as f32 * 0.5, WINDOW_HEIGHT as f32 * 0.5);
     let mut data = vec![0; WINDOW_WIDTH as usize * WINDOW_HEIGHT as usize * 4];
 
-    let mut exit = false;
-    while !exit {
-        for _ in 0..ITERATIONS_PER_FRAME {
-            let (dest_x, dest_y) = TRIANGLE_POINTS[rng.gen_range(0, 3)];
-            point = point.lerp(Point2D::new(dest_x, dest_y), 0.5);
-            put_pixel(&mut data, &point, FOREGROUND_COLOR);
-        }
-
-        device
-            .lock_surface_data(&mut surface)
-            .unwrap()
-            .data()
-            .copy_from_slice(&data);
-        device.present_surface(&mut surface).unwrap();
-
-        event_loop.poll_events(|event| match event {
+    event_loop.run(move |event, _, control_flow| {
+        match event {
             Event::WindowEvent {
-                event: WindowEvent::Destroyed,
+                event: WindowEvent::CloseRequested,
                 ..
             }
             | Event::DeviceEvent {
@@ -88,10 +78,24 @@ fn main() {
                         ..
                     }),
                 ..
-            } => exit = true,
-            _ => {}
-        });
-    }
+            } => *control_flow = ControlFlow::Exit,
+            _ => {
+                for _ in 0..ITERATIONS_PER_FRAME {
+                    let (dest_x, dest_y) = TRIANGLE_POINTS[rng.gen_range(0, 3)];
+                    point = point.lerp(Point2D::new(dest_x, dest_y), 0.5);
+                    put_pixel(&mut data, &point, FOREGROUND_COLOR);
+                }
+
+                device
+                    .lock_surface_data(&mut surface)
+                    .unwrap()
+                    .data()
+                    .copy_from_slice(&data);
+                device.present_surface(&mut surface).unwrap();
+                *control_flow = ControlFlow::Poll;
+            }
+        };
+    });
 }
 
 fn put_pixel(data: &mut [u8], point: &Point2D<f32>, color: u32) {

--- a/surfman/examples/threads.rs
+++ b/surfman/examples/threads.rs
@@ -17,11 +17,12 @@ use self::common::FilesystemResourceLoader;
 #[cfg(not(target_os = "android"))]
 use surfman::{ContextAttributeFlags, ContextAttributes, GLVersion};
 #[cfg(not(target_os = "android"))]
-use winit::dpi::PhysicalSize;
-#[cfg(not(target_os = "android"))]
-use winit::{DeviceEvent, Event, EventsLoop, KeyboardInput, VirtualKeyCode};
-#[cfg(not(target_os = "android"))]
-use winit::{WindowBuilder, WindowEvent};
+use winit::{
+    dpi::{LogicalSize, PhysicalSize},
+    event::{DeviceEvent, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::WindowBuilder
+};
 
 pub mod common;
 
@@ -86,17 +87,20 @@ static BACKGROUND_COLOR: [f32; 4] = [
 
 #[cfg(not(target_os = "android"))]
 fn main() {
-    let mut event_loop = EventsLoop::new();
-    let dpi = event_loop.get_primary_monitor().get_scale_factor();
+    let event_loop = EventLoop::new();
+    let dpi = event_loop.primary_monitor().unwrap().scale_factor();
     let window_size = Size2D::new(WINDOW_WIDTH, WINDOW_HEIGHT);
     let logical_size =
-        PhysicalSize::new(window_size.width as f64, window_size.height as f64).to_logical(dpi);
+        PhysicalSize::new(window_size.width, window_size.height)
+        .to_logical::<f64>(dpi);
+
     let window = WindowBuilder::new()
         .with_title("Multithreaded example")
-        .with_dimensions(logical_size)
+        .with_inner_size(logical_size)
         .build(&event_loop)
         .unwrap();
-    window.show();
+
+    window.set_visible(true);
 
     let connection = Connection::from_winit_window(&window).unwrap();
     let native_widget = connection
@@ -131,29 +135,24 @@ fn main() {
         Box::new(FilesystemResourceLoader),
         window_size,
     );
-    let mut exit = false;
 
-    while !exit {
-        app.tick(true);
+    event_loop.run(move |event, _, control_flow| match event {
+        Event::WindowEvent {
+            event: WindowEvent::CloseRequested,
+            ..
+        }
+        | Event::DeviceEvent {
+            event:
+                DeviceEvent::Key(KeyboardInput {
+                    virtual_keycode: Some(VirtualKeyCode::Escape),
+                    ..
+                }),
+            ..
+        } => *control_flow = ControlFlow::Exit,
+        _ => { app.tick(true); *control_flow = ControlFlow::Poll; }
+    });
 
-        event_loop.poll_events(|event| match event {
-            Event::WindowEvent {
-                event: WindowEvent::Destroyed,
-                ..
-            }
-            | Event::DeviceEvent {
-                event:
-                    DeviceEvent::Key(KeyboardInput {
-                        virtual_keycode: Some(VirtualKeyCode::Escape),
-                        ..
-                    }),
-                ..
-            } => exit = true,
-            _ => {}
-        });
-    }
 }
-
 pub struct App {
     main_from_worker_receiver: Receiver<Frame>,
     main_to_worker_sender: Sender<Surface>,
@@ -166,7 +165,14 @@ pub struct App {
     window_size: Size2D<i32>,
 }
 
+impl Drop for App {
+    fn drop(&mut self) {
+        self.device.destroy_context(&mut self.context).unwrap();
+    }
+}
+
 impl App {
+
     pub fn new(
         connection: Connection,
         adapter: Adapter,
@@ -533,7 +539,11 @@ fn worker_thread(
         }
 
         let old_surface = device.unbind_surface_from_context(&mut context).unwrap();
-        let new_surface = worker_from_main_receiver.recv().unwrap();
+        let new_surface = match worker_from_main_receiver.recv() {
+            Ok(surface) => surface,
+            Err(_) => break,
+        };
+
         device
             .bind_surface_to_context(&mut context, new_surface)
             .unwrap();
@@ -568,6 +578,8 @@ fn worker_thread(
         theta_y += ROTATION_SPEED_Y;
         theta_z += ROTATION_SPEED_Z;
     }
+
+    device.destroy_context(&mut context).unwrap();
 }
 
 struct Frame {


### PR DESCRIPTION
It looks like not all examples were updated when winit was [upgraded](https://github.com/servo/surfman/pull/223/files) from 0.19.1 to 0.24. This PR fixes the code under surfman/examples to build correctly using winit 0.24.

I've tested the 'threads' examples on linux+XWayland but not the 'chaos_game' example as I don't have access to macos. I've also not yet attempted to fix the build errors in the android example. 