### PR TITLE
Fix wrong enum variant on Windows and Android

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-22.04, windows-latest]
         rust: [nightly-2022-08-27, stable]
-        features: ["", "--features sm-winit"]
+        features: ["", "--features 'sm-winit sm-raw-window-handle'"]
         target: ["default"]
         include:
           # rust nightly

--- a/surfman/Cargo.toml
+++ b/surfman/Cargo.toml
@@ -17,7 +17,7 @@ gl_generator = "0.14"
 cfg_aliases = "0.1.0"
 
 [features]
-default = ["sm-winit"]
+default = ["sm-winit", "sm-raw-window-handle"]
 sm-angle = []
 sm-angle-builtin = ["mozangle"]
 sm-angle-default = ["sm-angle"]

--- a/surfman/src/platform/android/connection.rs
+++ b/surfman/src/platform/android/connection.rs
@@ -152,10 +152,10 @@ impl Connection {
         &self,
         raw_handle: raw_window_handle::RawWindowHandle,
     ) -> Result<NativeWidget, Error> {
-        use raw_window_handle::RawWindowHandle::Android;
+        use raw_window_handle::RawWindowHandle::AndroidNdk;
 
         match raw_handle {
-            Android(handle) => Ok(NativeWidget {
+            AndroidNdk(handle) => Ok(NativeWidget {
                 native_window: handle.a_native_window as *mut _,
             }),
             _ => Err(Error::IncompatibleNativeWidget),

--- a/surfman/src/platform/windows/wgl/connection.rs
+++ b/surfman/src/platform/windows/wgl/connection.rs
@@ -154,10 +154,10 @@ impl Connection {
         &self,
         raw_handle: raw_window_handle::RawWindowHandle,
     ) -> Result<NativeWidget, Error> {
-        use raw_window_handle::RawWindowHandle::Windows;
+        use raw_window_handle::RawWindowHandle::Win32;
 
         match raw_handle {
-            Windows(handle) => Ok(NativeWidget {
+            Win32(handle) => Ok(NativeWidget {
                 window_handle: handle.hwnd as HWND,
             }),
             _ => Err(Error::IncompatibleNativeWidget),


### PR DESCRIPTION
The variant of RawWindowHandle on Windows isn't correct.
I also added `sm-raw-window-handle` to the default feature and CI. So we can make sure it's correct on all platforms.