### PR TITLE
Fix transparency on macOS

### DIFF
--- a/surfman/src/platform/macos/cgl/connection.rs
+++ b/surfman/src/platform/macos/cgl/connection.rs
@@ -149,6 +149,7 @@ impl Connection {
         match raw_handle {
             AppKit(handle) => Ok(NativeWidget {
                 view: NSView(unsafe { msg_send![handle.ns_view as id, retain] }),
+                opaque: unsafe { msg_send![handle.ns_window as id, isOpaque] },
             }),
             _ => Err(Error::IncompatibleNativeWidget),
         }

--- a/surfman/src/platform/macos/system/connection.rs
+++ b/surfman/src/platform/macos/system/connection.rs
@@ -146,12 +146,14 @@ impl Connection {
         window: &Window,
     ) -> Result<NativeWidget, Error> {
         let ns_view = window.ns_view() as id;
+        let ns_window = window.ns_window() as id;
         if ns_view.is_null() {
             return Err(Error::IncompatibleNativeWidget);
         }
         unsafe {
             Ok(NativeWidget {
                 view: NSView(msg_send![ns_view, retain]),
+                opaque: msg_send![ns_window as id, isOpaque],
             })
         }
     }
@@ -164,6 +166,7 @@ impl Connection {
     ) -> NativeWidget {
         NativeWidget {
             view: NSView(raw as id),
+            opaque: true,
         }
     }
 
@@ -179,6 +182,7 @@ impl Connection {
         match raw_handle {
             AppKit(handle) => Ok(NativeWidget {
                 view: NSView(unsafe { msg_send![handle.ns_view as id, retain] }),
+                opaque: unsafe { msg_send![handle.ns_window as id, isOpaque] },
             }),
             _ => Err(Error::IncompatibleNativeWidget),
         }

--- a/surfman/src/platform/macos/system/surface.rs
+++ b/surfman/src/platform/macos/system/surface.rs
@@ -208,8 +208,6 @@ impl Device {
         let layer_size = CGSize::new(logical_size.width as f64, logical_size.height as f64);
         layer.set_frame(&CGRect::new(&CG_ZERO_POINT, &layer_size));
         layer.set_contents(front_surface.obj as id);
-        layer.set_opaque(true);
-        layer.set_contents_opaque(true);
         superlayer.add_sublayer(&layer);
 
         let view = native_widget.view.clone();
@@ -284,8 +282,6 @@ impl Device {
             view_info
                 .layer
                 .set_contents(view_info.front_surface.obj as id);
-            view_info.layer.set_opaque(true);
-            view_info.layer.set_contents_opaque(true);
             surface.io_surface = self.create_io_surface(&size, surface.access);
             surface.size = size;
         }

--- a/surfman/src/platform/macos/system/surface.rs
+++ b/surfman/src/platform/macos/system/surface.rs
@@ -78,6 +78,7 @@ pub(crate) struct ViewInfo {
     logical_size: NSSize,
     display_link: DisplayLink,
     next_vblank: Arc<VblankCond>,
+    opaque: bool,
 }
 
 struct VblankCond {
@@ -94,6 +95,8 @@ pub struct NSView(pub(crate) id);
 pub struct NativeWidget {
     /// The `NSView` object.
     pub view: NSView,
+    /// A bool value that indicates whether widget's NSWindow is opaque.
+    pub opaque: bool,
 }
 
 /// Represents the CPU view of the pixel data of this surface.
@@ -204,10 +207,13 @@ impl Device {
         }];
         let logical_size = logical_rect.size;
 
+        let opaque = native_widget.opaque;
         let layer = CALayer::new();
         let layer_size = CGSize::new(logical_size.width as f64, logical_size.height as f64);
         layer.set_frame(&CGRect::new(&CG_ZERO_POINT, &layer_size));
         layer.set_contents(front_surface.obj as id);
+        layer.set_opaque(opaque);
+        layer.set_contents_opaque(opaque);
         superlayer.add_sublayer(&layer);
 
         let view = native_widget.view.clone();
@@ -221,6 +227,7 @@ impl Device {
             logical_size,
             display_link,
             next_vblank,
+            opaque,
         }
     }
 
@@ -282,6 +289,8 @@ impl Device {
             view_info
                 .layer
                 .set_contents(view_info.front_surface.obj as id);
+            view_info.layer.set_opaque(view_info.opaque);
+            view_info.layer.set_contents_opaque(view_info.opaque);
             surface.io_surface = self.create_io_surface(&size, surface.access);
             surface.size = size;
         }


### PR DESCRIPTION
Unlike other platforms, macOS adds another opaque layer on CALayer.
This makes the window opaque even if winit window is set to transparent.

Edit: needs #261 to fix CI.