### PR TITLE
Update CI's nightly to 2023-02-01

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,29 +18,29 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-22.04, windows-latest]
-        rust: [nightly-2022-08-27, stable]
+        rust: [nightly-2023-02-01, stable]
         features: ["", "--features 'chains sm-winit sm-raw-window-handle'"]
         target: ["default"]
         include:
           # rust nightly
           - os: ubuntu-22.04
             features: "--features 'chains sm-wayland-default'"
-            rust: nightly-2022-08-27
+            rust: nightly-2023-02-01
             target: "default"
           - os: ubuntu-22.04
             target: "arm-linux-androideabi"
-            rust: nightly-2022-08-27
+            rust: nightly-2023-02-01
           - os: windows-latest
             features: "--features sm-angle-builtin"
-            rust: nightly-2022-08-27
+            rust: nightly-2023-02-01
             target: "default"
           - os: windows-latest
             features: "--features 'chains sm-no-wgl sm-angle-builtin'"
-            rust: nightly-2022-08-27
+            rust: nightly-2023-02-01
             target: "default"
           - os: windows-latest
             target: "aarch64-pc-windows-msvc"
-            rust: nightly-2022-08-27
+            rust: nightly-2023-02-01
           # rust stable
           - os: ubuntu-22.04
             features: "--features sm-wayland-default"
@@ -63,7 +63,7 @@ jobs:
           # nightly only
           - os: windows-latest
             target: "aarch64-uwp-windows-msvc"
-            rust: nightly-2022-08-27
+            rust: nightly-2023-02-01
     steps:
     - uses: actions/checkout@v3
     - name: Install deps on linux


### PR DESCRIPTION
There are [some dependencies](https://github.com/servo/surfman/actions/runs/6234057344/job/16920529163#step:5:110) with MSRV above 1.65.
This PR tries to update CI's nightly version to match with servo's [master branch](https://github.com/servo/servo/blob/master/rust-toolchain.toml).