### PR TITLE
chore(ci): update actions/checkout in GitHub workflows to v4

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,7 @@ jobs:
             target: "aarch64-uwp-windows-msvc"
             rust: nightly-2023-02-01
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install deps on linux
       if: startsWith(matrix.os, 'ubuntu')
       run: |


### PR DESCRIPTION
This updates [actions/checkout](https://github.com/actions/checkout) to v4, it's current version.

Changelog:

> ## v4.1.0
> - Add support for partial checkout filters
>
> ## v4.0.0
> - Support fetching without the --progress option
> - Update to node20