### PR TITLE
Fix some issues with the CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,29 +18,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-22.04, windows-latest]
-        rust: [nightly, stable]
+        rust: [stable]
         features: ["", "--features 'chains sm-winit sm-raw-window-handle'"]
         target: ["default"]
         include:
-          # rust nightly
-          - os: ubuntu-22.04
-            features: "--features 'chains sm-wayland-default'"
-            rust: nightly-2023-02-01
-            target: "default"
-          - os: ubuntu-22.04
-            target: "arm-linux-androideabi"
-            rust: nightly-2023-02-01
-          - os: windows-latest
-            features: "--features sm-angle-builtin"
-            rust: nightly-2023-02-01
-            target: "default"
-          - os: windows-latest
-            features: "--features 'chains sm-no-wgl sm-angle-builtin'"
-            rust: nightly-2023-02-01
-            target: "default"
-          - os: windows-latest
-            target: "aarch64-pc-windows-msvc"
-            rust: nightly-2023-02-01
           # rust stable
           - os: ubuntu-22.04
             features: "--features sm-wayland-default"
@@ -60,10 +41,6 @@ jobs:
           - os: windows-latest
             target: "aarch64-pc-windows-msvc"
             rust: stable
-          # nightly only
-          - os: windows-latest
-            target: "aarch64-uwp-windows-msvc"
-            rust: nightly-2023-02-01
     steps:
     - uses: actions/checkout@v4
     - name: Install deps on linux
@@ -97,10 +74,11 @@ jobs:
     name: Result
     runs-on: ubuntu-latest
     needs: ["Build"]
+    if: always()
     steps:
       - name: Mark the job as successful
+        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         run: exit 0
-        if: success()
       - name: Mark the job as unsuccessful
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1
-        if: "!success()"


### PR DESCRIPTION
- Servo is no longer using a Rust nightly build, so it's less important
to test surfman with rust nightly. Additionally, surfman no longer
compiles with the old version of Rust nightly that we were previously
using. Only test with stable rust.
- Make sure that the "Result" job always runs so it can block merging
if there is a failure on CI.