### PR TITLE
Remove the winit feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-22.04, windows-latest]
         rust: [stable]
-        features: ["", "--features 'chains sm-winit sm-raw-window-handle'"]
+        features: ["", "--features 'chains sm-raw-window-handle'"]
         target: ["default"]
         include:
           # rust stable

--- a/android-example/rust/Cargo.toml
+++ b/android-example/rust/Cargo.toml
@@ -15,16 +15,10 @@ panic = "abort"
 panic = "abort"
 
 [dependencies]
-android_logger = "0.8"
+android_logger = "0.13"
+euclid = { version = "0.22" }
 gl = "0.14"
-jni = "0.13"
+jni = "0.21"
 log = "0.4"
-winit = { version = "0.28.1", features = [ "android-native-activity" ] }
-
-[dependencies.euclid]
-version = "0.22"
-features = []
-
-[dependencies.surfman]
-path = "../../surfman"
-features = ["sm-test"]
+surfman = { path = "../../surfman", features = [ "sm-test" ] }
+winit = { version = "0.29.10", features = [ "android-native-activity", "rwh_05" ] }

--- a/surfman/Cargo.toml
+++ b/surfman/Cargo.toml
@@ -18,14 +18,13 @@ cfg_aliases = "0.1.0"
 
 [features]
 chains = ["fnv", "sparkle"]
-default = ["sm-winit", "sm-raw-window-handle"]
+default = ["sm-raw-window-handle"]
 sm-angle = []
 sm-angle-builtin = ["mozangle"]
 sm-angle-default = ["sm-angle"]
 sm-no-wgl = ["sm-angle-default"]
 sm-test = []
 sm-wayland-default = []
-sm-winit = ["winit"]
 sm-x11 = ["x11"]
 sm-raw-window-handle = ["raw-window-handle"]
 
@@ -38,7 +37,6 @@ libc = "0.2"
 log = "0.4"
 sparkle = { version = "0.1", optional = true }
 osmesa-sys = { version = "0.1", optional = true }
-winit = { version = "0.28.1", optional = true }
 raw-window-handle = { version = "0.5", optional = true }
 
 [dev-dependencies]
@@ -79,4 +77,3 @@ winapi = { version = "0.3", features = ["d3d11", "libloaderapi", "winbase", "win
 
 [target.'cfg(target_os = "android")'.dependencies]
 raw-window-handle = "0.5"
-winit = { version = "0.28.1", features = [ "android-native-activity" ] }

--- a/surfman/examples/chaos_game.rs
+++ b/surfman/examples/chaos_game.rs
@@ -49,8 +49,11 @@ fn main() {
 
     window.set_visible(true);
 
+    let window_size = window.inner_size();
+    let window_size = Size2D::new(window_size.width as i32, window_size.height as i32);
+    let handle = window.window_handle().unwrap();
     let native_widget = connection
-        .create_native_widget_from_winit_window(&window)
+        .create_native_widget_from_raw_window_handle(handle.as_raw(), window_size);
         .unwrap();
 
     let surface_type = SurfaceType::Widget { native_widget };

--- a/surfman/examples/threads.rs
+++ b/surfman/examples/threads.rs
@@ -23,6 +23,7 @@ use winit::{
     event_loop::{ControlFlow, EventLoop},
     window::WindowBuilder
 };
+use winit::raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
 
 pub mod common;
 
@@ -99,9 +100,14 @@ fn main() {
 
     window.set_visible(true);
 
-    let connection = Connection::from_winit_window(&window).unwrap();
+    let raw_display_handle = window.raw_display_handle();
+    let connection = Connection::from_raw_display_handle(raw_display_handle).unwrap();
+
+    let window_size = window.inner_size();
+    let window_size = Size2D::new(window_size.width as i32, window_size.height as i32);
+    let raw_window_handle = window.raw_window_handle();
     let native_widget = connection
-        .create_native_widget_from_winit_window(&window)
+        .create_native_widget_from_raw_window_handle(raw_window_handle, window_size)
         .unwrap();
     let adapter = connection.create_low_power_adapter().unwrap();
     let mut device = connection.create_device(&adapter).unwrap();

--- a/surfman/src/connection.rs
+++ b/surfman/src/connection.rs
@@ -9,9 +9,6 @@ use euclid::default::Size2D;
 
 use std::os::raw::c_void;
 
-#[cfg(feature = "sm-winit")]
-use winit::window::Window;
-
 /// Methods relating to display server connections.
 pub trait Connection: Sized {
     /// The adapter type associated with this connection.
@@ -57,24 +54,11 @@ pub trait Connection: Sized {
         native_device: Self::NativeDevice,
     ) -> Result<Self::Device, Error>;
 
-    /// Opens the display connection corresponding to the given `winit` window.
-    #[cfg(feature = "sm-winit")]
-    fn from_winit_window(window: &Window) -> Result<Self, Error>;
-
     /// Opens the display connection corresponding to the given raw display handle.
     #[cfg(feature = "sm-raw-window-handle")]
     fn from_raw_display_handle(
         raw_handle: raw_window_handle::RawDisplayHandle,
     ) -> Result<Self, Error>;
-
-    /// Creates a native widget type from the given `winit` window.
-    ///
-    /// This type can be later used to create surfaces that render to the window.
-    #[cfg(feature = "sm-winit")]
-    fn create_native_widget_from_winit_window(
-        &self,
-        window: &Window,
-    ) -> Result<Self::NativeWidget, Error>;
 
     /// Creates a native widget from a raw pointer
     unsafe fn create_native_widget_from_ptr(
@@ -85,8 +69,9 @@ pub trait Connection: Sized {
 
     /// Create a native widget type from the given `raw_window_handle::RawWindowHandle`.
     #[cfg(feature = "sm-raw-window-handle")]
-    fn create_native_widget_from_rwh(
+    fn create_native_widget_from_raw_window_handle(
         &self,
         window: raw_window_handle::RawWindowHandle,
+        size: Size2D<i32>,
     ) -> Result<Self::NativeWidget, Error>;
 }

--- a/surfman/src/error.rs
+++ b/surfman/src/error.rs
@@ -88,8 +88,6 @@ pub enum Error {
     IncompatibleAdapter,
     /// The native widget type does not match the supplied device.
     IncompatibleNativeWidget,
-    /// The `winit` window is incompatible with this backend.
-    IncompatibleWinitWindow,
     /// The `raw display handle` is incompatible with this backend.
     IncompatibleRawDisplayHandle,
     /// The native context does not match the supplied device.

--- a/surfman/src/implementation/connection.rs
+++ b/surfman/src/implementation/connection.rs
@@ -14,9 +14,6 @@ use euclid::default::Size2D;
 
 use std::os::raw::c_void;
 
-#[cfg(feature = "sm-winit")]
-use winit::window::Window;
-
 #[deny(unconditional_recursion)]
 impl ConnectionInterface for Connection {
     type Adapter = Adapter;
@@ -74,26 +71,11 @@ impl ConnectionInterface for Connection {
     }
 
     #[inline]
-    #[cfg(feature = "sm-winit")]
-    fn from_winit_window(window: &Window) -> Result<Connection, Error> {
-        Connection::from_winit_window(window)
-    }
-
-    #[inline]
     #[cfg(feature = "sm-raw-window-handle")]
     fn from_raw_display_handle(
         raw_handle: raw_window_handle::RawDisplayHandle,
     ) -> Result<Connection, Error> {
         Connection::from_raw_display_handle(raw_handle)
-    }
-
-    #[inline]
-    #[cfg(feature = "sm-winit")]
-    fn create_native_widget_from_winit_window(
-        &self,
-        window: &Window,
-    ) -> Result<NativeWidget, Error> {
-        Connection::create_native_widget_from_winit_window(self, window)
     }
 
     #[inline]
@@ -107,10 +89,11 @@ impl ConnectionInterface for Connection {
 
     #[inline]
     #[cfg(feature = "sm-raw-window-handle")]
-    fn create_native_widget_from_rwh(
+    fn create_native_widget_from_raw_window_handle(
         &self,
         window: raw_window_handle::RawWindowHandle,
+        size: Size2D<i32>,
     ) -> Result<NativeWidget, Error> {
-        Connection::create_native_widget_from_rwh(self, window)
+        Connection::create_native_widget_from_raw_window_handle(self, window, size)
     }
 }

--- a/surfman/src/platform/android/connection.rs
+++ b/surfman/src/platform/android/connection.rs
@@ -14,9 +14,6 @@ use euclid::default::Size2D;
 
 use std::os::raw::c_void;
 
-#[cfg(feature = "sm-winit")]
-use winit::window::Window;
-
 /// A connection to the display server.
 #[derive(Clone)]
 pub struct Connection;
@@ -100,38 +97,12 @@ impl Connection {
         })
     }
 
-    /// Opens the display connection corresponding to the given `winit` window.
-    #[cfg(feature = "sm-winit")]
-    #[inline]
-    pub fn from_winit_window(_: &Window) -> Result<Connection, Error> {
-        Ok(Connection)
-    }
-
     /// Opens the display connection corresponding to the given raw display handle.
     #[cfg(feature = "sm-raw-window-handle")]
     pub fn from_raw_display_handle(
         _: raw_window_handle::RawDisplayHandle,
     ) -> Result<Connection, Error> {
         Ok(Connection)
-    }
-
-    /// Creates a native widget type from the given `winit` window.
-    ///
-    /// This type can be later used to create surfaces that render to the window.
-    #[cfg(feature = "sm-winit")]
-    #[inline]
-    pub fn create_native_widget_from_winit_window(
-        &self,
-        window: &Window,
-    ) -> Result<NativeWidget, Error> {
-        use raw_window_handle::HasRawWindowHandle;
-        use raw_window_handle::RawWindowHandle::AndroidNdk;
-        match window.raw_window_handle() {
-            AndroidNdk(handle) => Ok(NativeWidget {
-                native_window: handle.a_native_window as *mut _,
-            }),
-            _ => Err(Error::IncompatibleNativeWidget),
-        }
     }
 
     /// Create a native widget from a raw pointer
@@ -148,9 +119,10 @@ impl Connection {
     /// Create a native widget type from the given `raw_window_handle::RawWindowHandle`.
     #[cfg(feature = "sm-raw-window-handle")]
     #[inline]
-    pub fn create_native_widget_from_rwh(
+    pub fn create_native_widget_from_raw_window_handle(
         &self,
         raw_handle: raw_window_handle::RawWindowHandle,
+        _size: Size2D<i32>,
     ) -> Result<NativeWidget, Error> {
         use raw_window_handle::RawWindowHandle::AndroidNdk;
 

--- a/surfman/src/platform/macos/cgl/connection.rs
+++ b/surfman/src/platform/macos/cgl/connection.rs
@@ -21,9 +21,6 @@ use crate::platform::macos::system::surface::NSView;
 #[cfg(feature = "sm-raw-window-handle")]
 use cocoa::base::id;
 
-#[cfg(feature = "sm-winit")]
-use winit::window::Window;
-
 pub use crate::platform::macos::system::connection::NativeConnection;
 
 /// A connection to the display server.
@@ -102,30 +99,12 @@ impl Connection {
             .map(Device)
     }
 
-    /// Opens the display connection corresponding to the given `winit` window.
-    #[cfg(feature = "sm-winit")]
-    pub fn from_winit_window(window: &Window) -> Result<Connection, Error> {
-        SystemConnection::from_winit_window(window).map(Connection)
-    }
-
     /// Opens the display connection corresponding to the given raw display handle.
     #[cfg(feature = "sm-raw-window-handle")]
     pub fn from_raw_display_handle(
         raw_handle: raw_window_handle::RawDisplayHandle,
     ) -> Result<Connection, Error> {
         SystemConnection::from_raw_display_handle(raw_handle).map(Connection)
-    }
-
-    /// Creates a native widget type from the given `winit` window.
-    ///
-    /// This type can be later used to create surfaces that render to the window.
-    #[cfg(feature = "sm-winit")]
-    #[inline]
-    pub fn create_native_widget_from_winit_window(
-        &self,
-        window: &Window,
-    ) -> Result<NativeWidget, Error> {
-        self.0.create_native_widget_from_winit_window(window)
     }
 
     /// Creates a native widget from a raw pointer
@@ -140,9 +119,10 @@ impl Connection {
     /// Create a native widget type from the given `raw_window_handle::RawWindowHandle`.
     #[cfg(feature = "sm-raw-window-handle")]
     #[inline]
-    pub fn create_native_widget_from_rwh(
+    pub fn create_native_widget_from_raw_window_handle(
         &self,
         raw_handle: raw_window_handle::RawWindowHandle,
+        _size: Size2D<i32>,
     ) -> Result<NativeWidget, Error> {
         use raw_window_handle::RawWindowHandle::AppKit;
 

--- a/surfman/src/platform/macos/system/connection.rs
+++ b/surfman/src/platform/macos/system/connection.rs
@@ -22,11 +22,6 @@ use euclid::default::Size2D;
 use std::os::raw::c_void;
 use std::str::FromStr;
 
-#[cfg(feature = "sm-winit")]
-use winit::platform::macos::WindowExtMacOS;
-#[cfg(feature = "sm-winit")]
-use winit::window::Window;
-
 /// A no-op connection.
 ///
 /// Connections to the CGS window server are implicit on macOS, so this is a zero-sized type.
@@ -123,39 +118,12 @@ impl Connection {
         self.create_device(&self.create_adapter()?)
     }
 
-    /// Opens the display connection corresponding to the given `winit` window.
-    #[cfg(feature = "sm-winit")]
-    pub fn from_winit_window(_: &Window) -> Result<Connection, Error> {
-        Connection::new()
-    }
-
     /// Opens the display connection corresponding to the given raw display handle.
     #[cfg(feature = "sm-raw-window-handle")]
     pub fn from_raw_display_handle(
         _: raw_window_handle::RawDisplayHandle,
     ) -> Result<Connection, Error> {
         Connection::new()
-    }
-
-    /// Creates a native widget type from the given `winit` window.
-    ///
-    /// This type can be later used to create surfaces that render to the window.
-    #[cfg(feature = "sm-winit")]
-    pub fn create_native_widget_from_winit_window(
-        &self,
-        window: &Window,
-    ) -> Result<NativeWidget, Error> {
-        let ns_view = window.ns_view() as id;
-        let ns_window = window.ns_window() as id;
-        if ns_view.is_null() {
-            return Err(Error::IncompatibleNativeWidget);
-        }
-        unsafe {
-            Ok(NativeWidget {
-                view: NSView(msg_send![ns_view, retain]),
-                opaque: msg_send![ns_window as id, isOpaque],
-            })
-        }
     }
 
     /// Create a native widget from a raw pointer
@@ -173,9 +141,10 @@ impl Connection {
     /// Create a native widget type from the given `raw_window_handle::RawWindowHandle`.
     #[cfg(feature = "sm-raw-window-handle")]
     #[inline]
-    pub fn create_native_widget_from_rwh(
+    pub fn create_native_widget_from_raw_window_handle(
         &self,
         raw_handle: raw_window_handle::RawWindowHandle,
+        _size: Size2D<i32>,
     ) -> Result<NativeWidget, Error> {
         use raw_window_handle::RawWindowHandle::AppKit;
 

--- a/surfman/src/platform/unix/generic/connection.rs
+++ b/surfman/src/platform/unix/generic/connection.rs
@@ -16,9 +16,6 @@ use euclid::default::Size2D;
 use std::os::raw::c_void;
 use std::sync::Arc;
 
-#[cfg(feature = "sm-winit")]
-use winit::window::Window;
-
 /// A no-op connection.
 #[derive(Clone)]
 pub struct Connection {
@@ -137,30 +134,11 @@ impl Connection {
         Device::new(self, &self.create_adapter()?)
     }
 
-    /// Opens the display connection corresponding to the given `winit` window.
-    #[inline]
-    #[cfg(feature = "sm-winit")]
-    pub fn from_winit_window(_: &Window) -> Result<Connection, Error> {
-        Err(Error::IncompatibleNativeWidget)
-    }
-
     /// Opens the display connection corresponding to the given raw display handle.
     #[cfg(feature = "sm-raw-window-handle")]
     pub fn from_raw_display_handle(
         _: raw_window_handle::RawDisplayHandle,
     ) -> Result<Connection, Error> {
-        Err(Error::IncompatibleNativeWidget)
-    }
-
-    /// Creates a native widget type from the given `winit` window.
-    ///
-    /// This type can be later used to create surfaces that render to the window.
-    #[inline]
-    #[cfg(feature = "sm-winit")]
-    pub fn create_native_widget_from_winit_window(
-        &self,
-        _: &Window,
-    ) -> Result<NativeWidget, Error> {
         Err(Error::IncompatibleNativeWidget)
     }
 
@@ -176,9 +154,10 @@ impl Connection {
     /// Create a native widget type from the given `raw_window_handle::RawWindowHandle`.
     #[cfg(feature = "sm-raw-window-handle")]
     #[inline]
-    pub fn create_native_widget_from_rwh(
+    pub fn create_native_widget_from_raw_window_handle(
         &self,
         _: raw_window_handle::RawWindowHandle,
+        _size: Size2D<i32>,
     ) -> Result<NativeWidget, Error> {
         Err(Error::IncompatibleNativeWidget)
     }

--- a/surfman/src/platform/unix/x11/connection.rs
+++ b/surfman/src/platform/unix/x11/connection.rs
@@ -20,11 +20,6 @@ use std::ptr;
 use std::sync::Arc;
 use x11::xlib::{Display, XCloseDisplay, XInitThreads, XLockDisplay, XOpenDisplay, XUnlockDisplay};
 
-#[cfg(feature = "sm-winit")]
-use winit::platform::x11::WindowExtX11;
-#[cfg(feature = "sm-winit")]
-use winit::window::Window;
-
 lazy_static! {
     static ref X_THREADS_INIT: () = {
         unsafe {
@@ -192,16 +187,6 @@ impl Connection {
         Device::new(self, &native_device.adapter)
     }
 
-    /// Opens the display connection corresponding to the given `winit` window.
-    #[cfg(feature = "sm-winit")]
-    pub fn from_winit_window(window: &Window) -> Result<Connection, Error> {
-        if let Some(display) = window.xlib_display() {
-            Connection::from_x11_display(display as *mut Display, false)
-        } else {
-            Err(Error::IncompatibleWinitWindow)
-        }
-    }
-
     /// Opens the display connection corresponding to the given raw display handle.
     #[cfg(feature = "sm-raw-window-handle")]
     pub fn from_raw_display_handle(
@@ -219,20 +204,6 @@ impl Connection {
         Connection::from_x11_display(display, false)
     }
 
-    /// Creates a native widget type from the given `winit` window.
-    ///
-    /// This type can be later used to create surfaces that render to the window.
-    #[cfg(feature = "sm-winit")]
-    pub fn create_native_widget_from_winit_window(
-        &self,
-        window: &Window,
-    ) -> Result<NativeWidget, Error> {
-        match window.xlib_window() {
-            Some(window) => Ok(NativeWidget { window }),
-            None => Err(Error::IncompatibleNativeWidget),
-        }
-    }
-
     /// Create a native widget from a raw pointer
     pub unsafe fn create_native_widget_from_ptr(
         &self,
@@ -246,9 +217,10 @@ impl Connection {
 
     /// Create a native widget type from the given `raw_window_handle::HasRawWindowHandle`.
     #[cfg(feature = "sm-raw-window-handle")]
-    pub fn create_native_widget_from_rwh(
+    pub fn create_native_widget_from_raw_window_handle(
         &self,
         raw_handle: raw_window_handle::RawWindowHandle,
+        _size: Size2D<i32>,
     ) -> Result<NativeWidget, Error> {
         use raw_window_handle::RawWindowHandle::Xlib;
 

--- a/surfman/src/platform/windows/angle/connection.rs
+++ b/surfman/src/platform/windows/angle/connection.rs
@@ -20,11 +20,6 @@ use std::os::raw::c_void;
 use winapi::shared::minwindef::UINT;
 use winapi::um::d3dcommon::{D3D_DRIVER_TYPE_UNKNOWN, D3D_DRIVER_TYPE_WARP};
 
-#[cfg(all(feature = "sm-winit", not(target_vendor = "uwp")))]
-use winit::platform::windows::WindowExtWindows;
-#[cfg(feature = "sm-winit")]
-use winit::window::Window;
-
 const INTEL_PCI_ID: UINT = 0x8086;
 
 /// A no-op connection.
@@ -133,48 +128,12 @@ impl Connection {
         Device::from_egl_display(egl_display)
     }
 
-    /// Opens the display connection corresponding to the given `winit` window.
-    #[cfg(feature = "sm-winit")]
-    pub fn from_winit_window(_: &Window) -> Result<Connection, Error> {
-        Connection::new()
-    }
-
     /// Opens the display connection corresponding to the given raw display handle.
     #[cfg(feature = "sm-raw-window-handle")]
     pub fn from_raw_display_handle(
         _: raw_window_handle::RawDisplayHandle,
     ) -> Result<Connection, Error> {
         Connection::new()
-    }
-
-    /// Creates a native widget type from the given `winit` window.
-    ///
-    /// This type can be later used to create surfaces that render to the window.
-    #[cfg(all(feature = "sm-winit", not(target_vendor = "uwp")))]
-    #[inline]
-    pub fn create_native_widget_from_winit_window(
-        &self,
-        window: &Window,
-    ) -> Result<NativeWidget, Error> {
-        let hwnd = window.hwnd() as EGLNativeWindowType;
-        if hwnd.is_null() {
-            Err(Error::IncompatibleNativeWidget)
-        } else {
-            Ok(NativeWidget {
-                egl_native_window: hwnd,
-            })
-        }
-    }
-
-    /// Creates a native widget type from the given `winit` window.
-    /// This is unsupported on UWP.
-    #[cfg(all(feature = "sm-winit", target_vendor = "uwp"))]
-    #[inline]
-    pub fn create_native_widget_from_winit_window(
-        &self,
-        _window: &Window,
-    ) -> Result<NativeWidget, Error> {
-        Err(Error::IncompatibleNativeWidget)
     }
 
     /// Create a native widget from a raw pointer
@@ -191,9 +150,10 @@ impl Connection {
     /// Create a native widget type from the given `raw_window_handle::RawWindowHandle`.
     #[cfg(feature = "sm-raw-window-handle")]
     #[inline]
-    pub fn create_native_widget_from_rwh(
+    pub fn create_native_widget_from_raw_window_handle(
         &self,
         handle: raw_window_handle::RawWindowHandle,
+        _size: Size2D<i32>,
     ) -> Result<NativeWidget, Error> {
         if let raw_window_handle::RawWindowHandle::Win32(handle) = handle {
             Ok(NativeWidget {

--- a/surfman/src/platform/windows/wgl/connection.rs
+++ b/surfman/src/platform/windows/wgl/connection.rs
@@ -15,11 +15,6 @@ use std::os::raw::c_void;
 
 use winapi::shared::windef::HWND;
 
-#[cfg(feature = "sm-winit")]
-use winit::platform::windows::WindowExtWindows;
-#[cfg(feature = "sm-winit")]
-use winit::window::Window;
-
 /// Represents a connection to the display server.
 ///
 /// Window server connections are implicit in the Win32 API, so this is a zero-sized type.
@@ -104,37 +99,12 @@ impl Connection {
         Device::from_native_device(native_device)
     }
 
-    /// Opens the display connection corresponding to the given `winit` window.
-    #[cfg(feature = "sm-winit")]
-    pub fn from_winit_window(_: &Window) -> Result<Connection, Error> {
-        Connection::new()
-    }
-
     /// Opens the display connection corresponding to the given raw display handle.
     #[cfg(feature = "sm-raw-window-handle")]
     pub fn from_raw_display_handle(
         _: raw_window_handle::RawDisplayHandle,
     ) -> Result<Connection, Error> {
         Connection::new()
-    }
-
-    /// Creates a native widget type from the given `winit` window.
-    ///
-    /// This type can be later used to create surfaces that render to the window.
-    #[cfg(feature = "sm-winit")]
-    #[inline]
-    pub fn create_native_widget_from_winit_window(
-        &self,
-        window: &Window,
-    ) -> Result<NativeWidget, Error> {
-        let hwnd = window.hwnd() as HWND;
-        if hwnd.is_null() {
-            Err(Error::IncompatibleNativeWidget)
-        } else {
-            Ok(NativeWidget {
-                window_handle: hwnd,
-            })
-        }
     }
 
     /// Create a native widget from a raw pointer
@@ -150,9 +120,10 @@ impl Connection {
 
     /// Create a native widget type from the given `raw_window_handle::HasRawWindowHandle`.
     #[cfg(feature = "sm-raw-window-handle")]
-    pub fn create_native_widget_from_rwh(
+    pub fn create_native_widget_from_raw_window_handle(
         &self,
         raw_handle: raw_window_handle::RawWindowHandle,
+        _size: Size2D<i32>,
     ) -> Result<NativeWidget, Error> {
         use raw_window_handle::RawWindowHandle::Win32;
 


### PR DESCRIPTION
Now that we can use raw_window_handle, drop the winit feature. This should make the dependency graph a little bit less complicated for crates that depend on surfman.

A few changes:

 - The Wayland implementation needs the size when creating a native widget from a raw window handle, so add that parameters Unfortunately, it doesn't look like there is another option here.
 - Rename `create_native_widget_from_rwh` to `create_native_widget_from_raw_window_handle`. There already exists API that uses the `raw_window_handle` terminology.
 - Try to fix the build of the android-example, which depended on the old winit and now depends on the new one.

This is a breaking API change, so the next release should be a major version bump.