### PR TITLE
Rename CI workflow to "Main"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Main
 
 on:
   push:


### PR DESCRIPTION
The "Rust" name is due to the fact that the workflow in this repository was adapted from the Rust repository's workflow.