### PR TITLE
Load libEGL.so.1 and fallback to unversioned soname

### DIFF
--- a/surfman/Cargo.toml
+++ b/surfman/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surfman"
 license = "MIT OR Apache-2.0 OR MPL-2.0"
 edition = "2018"
-version = "0.9.0"
+version = "0.9.1"
 authors = [
     "Patrick Walton <pcwalton@mimiga.net>",
     "Emilio Cobos Álvarez <emilio@crisal.io>",

--- a/surfman/src/platform/generic/egl/device.rs
+++ b/surfman/src/platform/generic/egl/device.rs
@@ -34,12 +34,15 @@ lazy_static! {
 #[cfg(not(any(target_os = "windows", target_os = "macos")))]
 lazy_static! {
     static ref EGL_LIBRARY: EGLLibraryWrapper = {
-        unsafe {
-            EGLLibraryWrapper(dlopen(
-                &b"libEGL.so\0"[0] as *const u8 as *const _,
-                RTLD_LAZY,
-            ))
+        for soname in [b"libEGL.so.1\0".as_ptr(), b"libEGL.so\0".as_ptr()] {
+            unsafe {
+                let handle = dlopen(soname as *const _, RTLD_LAZY);
+                if !handle.is_null() {
+                    return EGLLibraryWrapper(handle);
+                }
+            }
         }
+        panic!("Unable to load the libEGL shared object");
     };
 }
 


### PR DESCRIPTION
After the GStreamer update in Servo, the nightly binaries have been failing to launch on linux distros unless `libegl1-mesa-dev` or the equivalent package is installed in the runtime environment.

The binaries were loading before the GStreamer update was because the binary had a compile-time link to libEGL.so.1 due to gstreamer-sys crate. Because of this compile-time link, the dlsym calls are able to succesfully load the functions pointers even though the previous dlopen('libEGL.so') call returned a NULL handle indicating failure.

This patch makes surfman load `libEGL.so.1` first and fallback to `libEGL.so`. If neither are available, then the initialization panics, unlike the previous behavior where we silently succeed if the binary has a link to the libEGL shared object with the symbols for functions that are used at the runtime.

Fixes #276.