### PR TITLE
Update raw-window-handle to 0.6

### DIFF
--- a/surfman/Cargo.toml
+++ b/surfman/Cargo.toml
@@ -37,7 +37,7 @@ libc = "0.2"
 log = "0.4"
 sparkle = { version = "0.1", optional = true }
 osmesa-sys = { version = "0.1", optional = true }
-raw-window-handle = { version = "0.5", optional = true }
+raw-window-handle = { version = "0.6", optional = true }
 
 [dev-dependencies]
 clap = "2"
@@ -83,4 +83,4 @@ winapi = { version = "0.3", features = [
 ] }
 
 [target.'cfg(target_os = "android")'.dependencies]
-raw-window-handle = "0.5"
+raw-window-handle = "0.6"

--- a/surfman/src/platform/android/connection.rs
+++ b/surfman/src/platform/android/connection.rs
@@ -128,7 +128,7 @@ impl Connection {
 
         match raw_handle {
             AndroidNdk(handle) => Ok(NativeWidget {
-                native_window: handle.a_native_window as *mut _,
+                native_window: handle.a_native_window.as_ptr() as *mut _,
             }),
             _ => Err(Error::IncompatibleNativeWidget),
         }

--- a/surfman/src/platform/macos/cgl/connection.rs
+++ b/surfman/src/platform/macos/cgl/connection.rs
@@ -128,8 +128,8 @@ impl Connection {
 
         match raw_handle {
             AppKit(handle) => Ok(NativeWidget {
-                view: NSView(unsafe { msg_send![handle.ns_view as id, retain] }),
-                opaque: unsafe { msg_send![handle.ns_window as id, isOpaque] },
+                view: NSView(unsafe { msg_send![handle.ns_view.as_ptr() as id, retain] }),
+                opaque: unsafe { msg_send![handle.ns_view.as_ptr() as id, isOpaque] },
             }),
             _ => Err(Error::IncompatibleNativeWidget),
         }

--- a/surfman/src/platform/macos/system/connection.rs
+++ b/surfman/src/platform/macos/system/connection.rs
@@ -150,8 +150,8 @@ impl Connection {
 
         match raw_handle {
             AppKit(handle) => Ok(NativeWidget {
-                view: NSView(unsafe { msg_send![handle.ns_view as id, retain] }),
-                opaque: unsafe { msg_send![handle.ns_window as id, isOpaque] },
+                view: NSView(unsafe { msg_send![handle.ns_view.as_ptr() as id, retain] }),
+                opaque: unsafe { msg_send![handle.ns_view.as_ptr() as id, isOpaque] },
             }),
             _ => Err(Error::IncompatibleNativeWidget),
         }

--- a/surfman/src/platform/unix/wayland/connection.rs
+++ b/surfman/src/platform/unix/wayland/connection.rs
@@ -165,7 +165,9 @@ impl Connection {
         use raw_window_handle::WaylandDisplayHandle;
         unsafe {
             let wayland_display = match raw_handle {
-                Wayland(WaylandDisplayHandle { display, .. }) => display as *mut wl_display,
+                Wayland(WaylandDisplayHandle { display, .. }) => {
+                    display.as_ptr() as *mut wl_display
+                }
                 _ => return Err(Error::IncompatibleRawDisplayHandle),
             };
 
@@ -195,7 +197,7 @@ impl Connection {
         use raw_window_handle::RawWindowHandle::Wayland;
 
         let wayland_surface = match raw_handle {
-            Wayland(handle) => handle.surface as *mut wl_proxy,
+            Wayland(handle) => handle.surface.as_ptr() as *mut wl_proxy,
             _ => return Err(Error::IncompatibleNativeWidget),
         };
 

--- a/surfman/src/platform/unix/x11/connection.rs
+++ b/surfman/src/platform/unix/x11/connection.rs
@@ -196,7 +196,10 @@ impl Connection {
         use raw_window_handle::RawDisplayHandle::Xlib;
         use raw_window_handle::XlibDisplayHandle;
         let display = match raw_handle {
-            Xlib(XlibDisplayHandle { display, .. }) => display as *mut Display,
+            Xlib(XlibDisplayHandle { display, .. }) => match display {
+                Some(display) => display.as_ptr() as *mut Display,
+                None => return Err(Error::ConnectionRequired),
+            },
             Xcb(_) => return Err(Error::Unimplemented),
             _ => return Err(Error::IncompatibleRawDisplayHandle),
         };

--- a/surfman/src/platform/windows/angle/connection.rs
+++ b/surfman/src/platform/windows/angle/connection.rs
@@ -157,7 +157,7 @@ impl Connection {
     ) -> Result<NativeWidget, Error> {
         if let raw_window_handle::RawWindowHandle::Win32(handle) = handle {
             Ok(NativeWidget {
-                egl_native_window: handle.hwnd as EGLNativeWindowType,
+                egl_native_window: handle.hwnd.get() as EGLNativeWindowType,
             })
         } else {
             Err(Error::IncompatibleNativeWidget)

--- a/surfman/src/platform/windows/wgl/connection.rs
+++ b/surfman/src/platform/windows/wgl/connection.rs
@@ -129,7 +129,7 @@ impl Connection {
 
         match raw_handle {
             Win32(handle) => Ok(NativeWidget {
-                window_handle: handle.hwnd as HWND,
+                window_handle: handle.hwnd.get() as HWND,
             }),
             _ => Err(Error::IncompatibleNativeWidget),
         }


### PR DESCRIPTION
Althought there is this PR [#275] which aims to update raw-window-handle, which also introduced oddly named `_05` and it kind of staled for sometimes now and failed CI on some platform.

This PR only update raw-window-handle to 0.6, hopes it will pass all the platform ci checks.