### PR TITLE
Fix X11 build error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         include:
           # rust stable
           - os: ubuntu-22.04
-            features: "--features sm-wayland-default"
+            features: "--features 'sm-x11 sm-wayland-default'"
             rust: stable
             target: "default"
           - os: ubuntu-22.04

--- a/surfman/src/platform/unix/x11/connection.rs
+++ b/surfman/src/platform/unix/x11/connection.rs
@@ -211,7 +211,10 @@ impl Connection {
         use rwh_06::RawDisplayHandle::Xlib;
         use rwh_06::XlibDisplayHandle;
         let display = match handle.as_raw() {
-            Xlib(XlibDisplayHandle { display, .. }) => display as *mut Display,
+            Xlib(XlibDisplayHandle {
+                display: Some(display),
+                ..
+            }) => display.as_ptr() as *mut Display,
             Xcb(_) => return Err(Error::Unimplemented),
             _ => return Err(Error::IncompatibleRawDisplayHandle),
         };


### PR DESCRIPTION
Caught in servo/webxr's CI pipeline https://github.com/servo/webxr/actions/runs/8358606375/job/22880254127

Added the sm-x11 feature to the workflows to ensure it doesn't regress again.