### PR TITLE
Fix some simple clippy lints

### DIFF
--- a/surfman/build.rs
+++ b/surfman/build.rs
@@ -38,18 +38,18 @@ fn main() {
         || (target_os == "windows" && cfg!(feature = "sm-angle"))
         || target_family.as_ref().map_or(false, |f| f == "unix")
     {
-        let mut file = File::create(&dest.join("egl_bindings.rs")).unwrap();
+        let mut file = File::create(dest.join("egl_bindings.rs")).unwrap();
         let registry = Registry::new(Api::Egl, (1, 5), Profile::Core, Fallbacks::All, []);
         registry.write_bindings(StructGenerator, &mut file).unwrap();
     }
 
     // Generate GL bindings.
     if target_os == "android" {
-        let mut file = File::create(&dest.join("gl_bindings.rs")).unwrap();
+        let mut file = File::create(dest.join("gl_bindings.rs")).unwrap();
         let registry = Registry::new(Api::Gles2, (3, 0), Profile::Core, Fallbacks::All, []);
         registry.write_bindings(StructGenerator, &mut file).unwrap();
     } else {
-        let mut file = File::create(&dest.join("gl_bindings.rs")).unwrap();
+        let mut file = File::create(dest.join("gl_bindings.rs")).unwrap();
         let registry = Registry::new(Api::Gl, (3, 3), Profile::Core, Fallbacks::All, []);
         registry.write_bindings(StructGenerator, &mut file).unwrap();
     }

--- a/surfman/src/lib.rs
+++ b/surfman/src/lib.rs
@@ -63,6 +63,7 @@ pub(crate) use crate::gl::Gles2 as Gl;
 mod gl_utils;
 mod renderbuffers;
 
+#[allow(clippy::all)]
 mod gl {
     include!(concat!(env!("OUT_DIR"), "/gl_bindings.rs"));
 }
@@ -73,6 +74,7 @@ mod gl {
     unix
 ))]
 #[allow(non_camel_case_types)]
+#[allow(clippy::all)]
 mod egl {
     use std::os::raw::{c_long, c_void};
     pub type khronos_utime_nanoseconds_t = khronos_uint64_t;

--- a/surfman/src/platform/generic/multi/connection.rs
+++ b/surfman/src/platform/generic/multi/connection.rs
@@ -147,10 +147,10 @@ where
     /// Device handles are local to a single thread.
     pub fn create_device(&self, adapter: &Adapter<Def, Alt>) -> Result<Device<Def, Alt>, Error> {
         match (self, adapter) {
-            (&Connection::Default(ref connection), &Adapter::Default(ref adapter)) => {
+            (Connection::Default(connection), Adapter::Default(adapter)) => {
                 connection.create_device(adapter).map(Device::Default)
             }
-            (&Connection::Alternate(ref connection), &Adapter::Alternate(ref adapter)) => {
+            (Connection::Alternate(connection), Adapter::Alternate(adapter)) => {
                 connection.create_device(adapter).map(Device::Alternate)
             }
             _ => Err(Error::IncompatibleAdapter),
@@ -164,13 +164,13 @@ where
         native_device: NativeDevice<Def, Alt>,
     ) -> Result<Device<Def, Alt>, Error> {
         match self {
-            &Connection::Default(ref connection) => match native_device {
+            Connection::Default(connection) => match native_device {
                 NativeDevice::Default(native_device) => connection
                     .create_device_from_native_device(native_device)
                     .map(Device::Default),
                 _ => Err(Error::IncompatibleNativeDevice),
             },
-            &Connection::Alternate(ref connection) => match native_device {
+            Connection::Alternate(connection) => match native_device {
                 NativeDevice::Alternate(native_device) => connection
                     .create_device_from_native_device(native_device)
                     .map(Device::Alternate),

--- a/surfman/src/platform/generic/multi/context.rs
+++ b/surfman/src/platform/generic/multi/context.rs
@@ -107,10 +107,7 @@ where
                     .create_context(descriptor, shared)
                     .map(Context::Default)
             }
-            (
-                &mut Device::Alternate(ref mut device),
-                ContextDescriptor::Alternate(descriptor),
-            ) => {
+            (&mut Device::Alternate(ref mut device), ContextDescriptor::Alternate(descriptor)) => {
                 let shared = match share_with {
                     Some(Context::Alternate(other)) => Some(other),
                     Some(_) => {
@@ -230,8 +227,7 @@ where
         surface: Surface<Def, Alt>,
     ) -> Result<(), (Error, Surface<Def, Alt>)> {
         match (self, &mut *context) {
-            (Device::Default(device), &mut Context::Default(ref mut context)) => match surface
-            {
+            (Device::Default(device), &mut Context::Default(ref mut context)) => match surface {
                 Surface::Default(surface) => device
                     .bind_surface_to_context(context, surface)
                     .map_err(|(err, surface)| (err, Surface::Default(surface))),
@@ -277,10 +273,9 @@ where
             (Device::Default(device), ContextDescriptor::Default(context_descriptor)) => {
                 device.context_descriptor_attributes(context_descriptor)
             }
-            (
-                Device::Alternate(device),
-                ContextDescriptor::Alternate(context_descriptor),
-            ) => device.context_descriptor_attributes(context_descriptor),
+            (Device::Alternate(device), ContextDescriptor::Alternate(context_descriptor)) => {
+                device.context_descriptor_attributes(context_descriptor)
+            }
             _ => panic!("Incompatible context!"),
         }
     }
@@ -314,12 +309,8 @@ where
     /// a new one, the new context might have the same ID as the destroyed one.
     pub fn context_id(&self, context: &Context<Def, Alt>) -> ContextID {
         match (self, context) {
-            (Device::Default(device), Context::Default(context)) => {
-                device.context_id(context)
-            }
-            (Device::Alternate(device), Context::Alternate(context)) => {
-                device.context_id(context)
-            }
+            (Device::Default(device), Context::Default(context)) => device.context_id(context),
+            (Device::Alternate(device), Context::Alternate(context)) => device.context_id(context),
             _ => panic!("Incompatible context!"),
         }
     }

--- a/surfman/src/platform/generic/multi/context.rs
+++ b/surfman/src/platform/generic/multi/context.rs
@@ -95,9 +95,9 @@ where
         share_with: Option<&Context<Def, Alt>>,
     ) -> Result<Context<Def, Alt>, Error> {
         match (&mut *self, descriptor) {
-            (&mut Device::Default(ref mut device), &ContextDescriptor::Default(ref descriptor)) => {
+            (&mut Device::Default(ref mut device), ContextDescriptor::Default(descriptor)) => {
                 let shared = match share_with {
-                    Some(&Context::Default(ref other)) => Some(other),
+                    Some(Context::Default(other)) => Some(other),
                     Some(_) => {
                         return Err(Error::IncompatibleSharedContext);
                     }
@@ -109,10 +109,10 @@ where
             }
             (
                 &mut Device::Alternate(ref mut device),
-                &ContextDescriptor::Alternate(ref descriptor),
+                ContextDescriptor::Alternate(descriptor),
             ) => {
                 let shared = match share_with {
-                    Some(&Context::Alternate(ref other)) => Some(other),
+                    Some(Context::Alternate(other)) => Some(other),
                     Some(_) => {
                         return Err(Error::IncompatibleSharedContext);
                     }
@@ -132,13 +132,13 @@ where
         native_context: NativeContext<Def, Alt>,
     ) -> Result<Context<Def, Alt>, Error> {
         match self {
-            &Device::Default(ref device) => match native_context {
+            Device::Default(device) => match native_context {
                 NativeContext::Default(native_context) => device
                     .create_context_from_native_context(native_context)
                     .map(Context::Default),
                 _ => Err(Error::IncompatibleNativeContext),
             },
-            &Device::Alternate(ref device) => match native_context {
+            Device::Alternate(device) => match native_context {
                 NativeContext::Alternate(native_context) => device
                     .create_context_from_native_context(native_context)
                     .map(Context::Alternate),
@@ -152,10 +152,10 @@ where
     /// The context must have been created on this device.
     pub fn destroy_context(&self, context: &mut Context<Def, Alt>) -> Result<(), Error> {
         match (self, &mut *context) {
-            (&Device::Default(ref device), &mut Context::Default(ref mut context)) => {
+            (Device::Default(device), &mut Context::Default(ref mut context)) => {
                 device.destroy_context(context)
             }
-            (&Device::Alternate(ref device), &mut Context::Alternate(ref mut context)) => {
+            (Device::Alternate(device), &mut Context::Alternate(ref mut context)) => {
                 device.destroy_context(context)
             }
             _ => Err(Error::IncompatibleContext),
@@ -165,10 +165,10 @@ where
     /// Returns the native context underlying this context.
     pub fn native_context(&self, context: &Context<Def, Alt>) -> NativeContext<Def, Alt> {
         match (self, context) {
-            (&Device::Default(ref device), &Context::Default(ref context)) => {
+            (Device::Default(device), Context::Default(context)) => {
                 NativeContext::Default(device.native_context(context))
             }
-            (&Device::Alternate(ref device), &Context::Alternate(ref context)) => {
+            (Device::Alternate(device), Context::Alternate(context)) => {
                 NativeContext::Alternate(device.native_context(context))
             }
             _ => panic!("Incompatible context!"),
@@ -178,10 +178,10 @@ where
     /// Returns the descriptor that this context was created with.
     pub fn context_descriptor(&self, context: &Context<Def, Alt>) -> ContextDescriptor<Def, Alt> {
         match (self, context) {
-            (&Device::Default(ref device), &Context::Default(ref context)) => {
+            (Device::Default(device), Context::Default(context)) => {
                 ContextDescriptor::Default(device.context_descriptor(context))
             }
-            (&Device::Alternate(ref device), &Context::Alternate(ref context)) => {
+            (Device::Alternate(device), Context::Alternate(context)) => {
                 ContextDescriptor::Alternate(device.context_descriptor(context))
             }
             _ => panic!("Incompatible context!"),
@@ -193,10 +193,10 @@ where
     /// After calling this function, it is valid to use OpenGL rendering commands.
     pub fn make_context_current(&self, context: &Context<Def, Alt>) -> Result<(), Error> {
         match (self, context) {
-            (&Device::Default(ref device), &Context::Default(ref context)) => {
+            (Device::Default(device), Context::Default(context)) => {
                 device.make_context_current(context)
             }
-            (&Device::Alternate(ref device), &Context::Alternate(ref context)) => {
+            (Device::Alternate(device), Context::Alternate(context)) => {
                 device.make_context_current(context)
             }
             _ => Err(Error::IncompatibleContext),
@@ -209,8 +209,8 @@ where
     /// made current.
     pub fn make_no_context_current(&self) -> Result<(), Error> {
         match self {
-            &Device::Default(ref device) => device.make_no_context_current(),
-            &Device::Alternate(ref device) => device.make_no_context_current(),
+            Device::Default(device) => device.make_no_context_current(),
+            Device::Alternate(device) => device.make_no_context_current(),
         }
     }
 
@@ -230,14 +230,14 @@ where
         surface: Surface<Def, Alt>,
     ) -> Result<(), (Error, Surface<Def, Alt>)> {
         match (self, &mut *context) {
-            (&Device::Default(ref device), &mut Context::Default(ref mut context)) => match surface
+            (Device::Default(device), &mut Context::Default(ref mut context)) => match surface
             {
                 Surface::Default(surface) => device
                     .bind_surface_to_context(context, surface)
                     .map_err(|(err, surface)| (err, Surface::Default(surface))),
                 _ => Err((Error::IncompatibleSurface, surface)),
             },
-            (&Device::Alternate(ref device), &mut Context::Alternate(ref mut context)) => {
+            (Device::Alternate(device), &mut Context::Alternate(ref mut context)) => {
                 match surface {
                     Surface::Alternate(surface) => device
                         .bind_surface_to_context(context, surface)
@@ -258,10 +258,10 @@ where
         context: &mut Context<Def, Alt>,
     ) -> Result<Option<Surface<Def, Alt>>, Error> {
         match (self, &mut *context) {
-            (&Device::Default(ref device), &mut Context::Default(ref mut context)) => device
+            (Device::Default(device), &mut Context::Default(ref mut context)) => device
                 .unbind_surface_from_context(context)
                 .map(|surface| surface.map(Surface::Default)),
-            (&Device::Alternate(ref device), &mut Context::Alternate(ref mut context)) => device
+            (Device::Alternate(device), &mut Context::Alternate(ref mut context)) => device
                 .unbind_surface_from_context(context)
                 .map(|surface| surface.map(Surface::Alternate)),
             _ => Err(Error::IncompatibleContext),
@@ -274,12 +274,12 @@ where
         context_descriptor: &ContextDescriptor<Def, Alt>,
     ) -> ContextAttributes {
         match (self, context_descriptor) {
-            (&Device::Default(ref device), &ContextDescriptor::Default(ref context_descriptor)) => {
+            (Device::Default(device), ContextDescriptor::Default(context_descriptor)) => {
                 device.context_descriptor_attributes(context_descriptor)
             }
             (
-                &Device::Alternate(ref device),
-                &ContextDescriptor::Alternate(ref context_descriptor),
+                Device::Alternate(device),
+                ContextDescriptor::Alternate(context_descriptor),
             ) => device.context_descriptor_attributes(context_descriptor),
             _ => panic!("Incompatible context!"),
         }
@@ -298,10 +298,10 @@ where
         symbol_name: &str,
     ) -> *const c_void {
         match (self, context) {
-            (&Device::Default(ref device), &Context::Default(ref context)) => {
+            (Device::Default(device), Context::Default(context)) => {
                 device.get_proc_address(context, symbol_name)
             }
-            (&Device::Alternate(ref device), &Context::Alternate(ref context)) => {
+            (Device::Alternate(device), Context::Alternate(context)) => {
                 device.get_proc_address(context, symbol_name)
             }
             _ => panic!("Incompatible context!"),
@@ -314,10 +314,10 @@ where
     /// a new one, the new context might have the same ID as the destroyed one.
     pub fn context_id(&self, context: &Context<Def, Alt>) -> ContextID {
         match (self, context) {
-            (&Device::Default(ref device), &Context::Default(ref context)) => {
+            (Device::Default(device), Context::Default(context)) => {
                 device.context_id(context)
             }
-            (&Device::Alternate(ref device), &Context::Alternate(ref context)) => {
+            (Device::Alternate(device), Context::Alternate(context)) => {
                 device.context_id(context)
             }
             _ => panic!("Incompatible context!"),
@@ -332,10 +332,10 @@ where
         context: &Context<Def, Alt>,
     ) -> Result<Option<SurfaceInfo>, Error> {
         match (self, context) {
-            (&Device::Default(ref device), &Context::Default(ref context)) => {
+            (Device::Default(device), Context::Default(context)) => {
                 device.context_surface_info(context)
             }
-            (&Device::Alternate(ref device), &Context::Alternate(ref context)) => {
+            (Device::Alternate(device), Context::Alternate(context)) => {
                 device.context_surface_info(context)
             }
             _ => Err(Error::IncompatibleContext),

--- a/surfman/src/platform/generic/multi/surface.rs
+++ b/surfman/src/platform/generic/multi/surface.rs
@@ -155,8 +155,7 @@ where
         surface: Surface<Def, Alt>,
     ) -> Result<SurfaceTexture<Def, Alt>, (Error, Surface<Def, Alt>)> {
         match (self, &mut *context) {
-            (Device::Default(device), &mut Context::Default(ref mut context)) => match surface
-            {
+            (Device::Default(device), &mut Context::Default(ref mut context)) => match surface {
                 Surface::Default(surface) => {
                     match device.create_surface_texture(context, surface) {
                         Ok(surface_texture) => Ok(SurfaceTexture::Default(surface_texture)),
@@ -193,18 +192,15 @@ where
         surface: &mut Surface<Def, Alt>,
     ) -> Result<(), Error> {
         match (self, &mut *context) {
-            (Device::Default(device), &mut Context::Default(ref mut context)) => {
-                match *surface {
-                    Surface::Default(ref mut surface) => device.destroy_surface(context, surface),
-                    _ => Err(Error::IncompatibleSurface),
-                }
-            }
-            (Device::Alternate(device), &mut Context::Alternate(ref mut context)) => {
-                match *surface {
-                    Surface::Alternate(ref mut surface) => device.destroy_surface(context, surface),
-                    _ => Err(Error::IncompatibleSurface),
-                }
-            }
+            (Device::Default(device), &mut Context::Default(ref mut context)) => match *surface {
+                Surface::Default(ref mut surface) => device.destroy_surface(context, surface),
+                _ => Err(Error::IncompatibleSurface),
+            },
+            (Device::Alternate(device), &mut Context::Alternate(ref mut context)) => match *surface
+            {
+                Surface::Alternate(ref mut surface) => device.destroy_surface(context, surface),
+                _ => Err(Error::IncompatibleSurface),
+            },
             _ => Err(Error::IncompatibleContext),
         }
     }

--- a/surfman/src/platform/generic/multi/surface.rs
+++ b/surfman/src/platform/generic/multi/surface.rs
@@ -107,7 +107,7 @@ where
         surface_type: SurfaceType<NativeWidget<Def, Alt>>,
     ) -> Result<Surface<Def, Alt>, Error> {
         match (&mut *self, context) {
-            (&mut Device::Default(ref mut device), &Context::Default(ref context)) => {
+            (&mut Device::Default(ref mut device), Context::Default(context)) => {
                 let surface_type = match surface_type {
                     SurfaceType::Generic { size } => SurfaceType::Generic { size },
                     SurfaceType::Widget {
@@ -121,7 +121,7 @@ where
                     .create_surface(context, surface_access, surface_type)
                     .map(Surface::Default)
             }
-            (&mut Device::Alternate(ref mut device), &Context::Alternate(ref context)) => {
+            (&mut Device::Alternate(ref mut device), Context::Alternate(context)) => {
                 let surface_type = match surface_type {
                     SurfaceType::Generic { size } => SurfaceType::Generic { size },
                     SurfaceType::Widget {
@@ -155,7 +155,7 @@ where
         surface: Surface<Def, Alt>,
     ) -> Result<SurfaceTexture<Def, Alt>, (Error, Surface<Def, Alt>)> {
         match (self, &mut *context) {
-            (&Device::Default(ref device), &mut Context::Default(ref mut context)) => match surface
+            (Device::Default(device), &mut Context::Default(ref mut context)) => match surface
             {
                 Surface::Default(surface) => {
                     match device.create_surface_texture(context, surface) {
@@ -165,7 +165,7 @@ where
                 }
                 _ => Err((Error::IncompatibleSurface, surface)),
             },
-            (&Device::Alternate(ref device), &mut Context::Alternate(ref mut context)) => {
+            (Device::Alternate(device), &mut Context::Alternate(ref mut context)) => {
                 match surface {
                     Surface::Alternate(surface) => {
                         match device.create_surface_texture(context, surface) {
@@ -193,13 +193,13 @@ where
         surface: &mut Surface<Def, Alt>,
     ) -> Result<(), Error> {
         match (self, &mut *context) {
-            (&Device::Default(ref device), &mut Context::Default(ref mut context)) => {
+            (Device::Default(device), &mut Context::Default(ref mut context)) => {
                 match *surface {
                     Surface::Default(ref mut surface) => device.destroy_surface(context, surface),
                     _ => Err(Error::IncompatibleSurface),
                 }
             }
-            (&Device::Alternate(ref device), &mut Context::Alternate(ref mut context)) => {
+            (Device::Alternate(device), &mut Context::Alternate(ref mut context)) => {
                 match *surface {
                     Surface::Alternate(ref mut surface) => device.destroy_surface(context, surface),
                     _ => Err(Error::IncompatibleSurface),
@@ -222,7 +222,7 @@ where
         surface_texture: SurfaceTexture<Def, Alt>,
     ) -> Result<Surface<Def, Alt>, (Error, SurfaceTexture<Def, Alt>)> {
         match (self, &mut *context) {
-            (&Device::Default(ref device), &mut Context::Default(ref mut context)) => {
+            (Device::Default(device), &mut Context::Default(ref mut context)) => {
                 match surface_texture {
                     SurfaceTexture::Default(surface_texture) => {
                         match device.destroy_surface_texture(context, surface_texture) {
@@ -235,7 +235,7 @@ where
                     _ => Err((Error::IncompatibleSurfaceTexture, surface_texture)),
                 }
             }
-            (&Device::Alternate(ref device), &mut Context::Alternate(ref mut context)) => {
+            (Device::Alternate(device), &mut Context::Alternate(ref mut context)) => {
                 match surface_texture {
                     SurfaceTexture::Alternate(surface_texture) => {
                         match device.destroy_surface_texture(context, surface_texture) {
@@ -265,11 +265,11 @@ where
         surface: &mut Surface<Def, Alt>,
     ) -> Result<(), Error> {
         match (self, context) {
-            (&Device::Default(ref device), &Context::Default(ref context)) => match *surface {
+            (Device::Default(device), Context::Default(context)) => match *surface {
                 Surface::Default(ref mut surface) => device.present_surface(context, surface),
                 _ => Err(Error::IncompatibleSurface),
             },
-            (&Device::Alternate(ref device), &Context::Alternate(ref context)) => match *surface {
+            (Device::Alternate(device), Context::Alternate(context)) => match *surface {
                 Surface::Alternate(ref mut surface) => device.present_surface(context, surface),
                 _ => Err(Error::IncompatibleSurface),
             },
@@ -285,11 +285,11 @@ where
         size: Size2D<i32>,
     ) -> Result<(), Error> {
         match (self, context) {
-            (&Device::Default(ref device), &Context::Default(ref context)) => match *surface {
+            (Device::Default(device), Context::Default(context)) => match *surface {
                 Surface::Default(ref mut surface) => device.resize_surface(context, surface, size),
                 _ => Err(Error::IncompatibleSurface),
             },
-            (&Device::Alternate(ref device), &Context::Alternate(ref context)) => match *surface {
+            (Device::Alternate(device), Context::Alternate(context)) => match *surface {
                 Surface::Alternate(ref mut surface) => {
                     device.resize_surface(context, surface, size)
                 }
@@ -318,10 +318,10 @@ where
     /// 0, the default framebuffer, depending on platform.
     pub fn surface_info(&self, surface: &Surface<Def, Alt>) -> SurfaceInfo {
         match (self, surface) {
-            (&Device::Default(ref device), Surface::Default(ref surface)) => {
+            (Device::Default(device), Surface::Default(ref surface)) => {
                 device.surface_info(surface)
             }
-            (&Device::Alternate(ref device), Surface::Alternate(ref surface)) => {
+            (Device::Alternate(device), Surface::Alternate(ref surface)) => {
                 device.surface_info(surface)
             }
             _ => panic!("Incompatible context!"),
@@ -333,10 +333,10 @@ where
     /// It is only legal to read from, not write to, this texture object.
     pub fn surface_texture_object(&self, surface_texture: &SurfaceTexture<Def, Alt>) -> GLuint {
         match (self, surface_texture) {
-            (&Device::Default(ref device), SurfaceTexture::Default(ref surface_texture)) => {
+            (Device::Default(device), SurfaceTexture::Default(ref surface_texture)) => {
                 device.surface_texture_object(surface_texture)
             }
-            (&Device::Alternate(ref device), SurfaceTexture::Alternate(ref surface_texture)) => {
+            (Device::Alternate(device), SurfaceTexture::Alternate(ref surface_texture)) => {
                 device.surface_texture_object(surface_texture)
             }
             _ => panic!("Incompatible context!"),

--- a/surfman/src/platform/macos/cgl/context.rs
+++ b/surfman/src/platform/macos/cgl/context.rs
@@ -43,7 +43,7 @@ const kCGLOGLPVersion_3_2_Core: CGLPixelFormatAttribute = 0x3200;
 #[allow(non_upper_case_globals)]
 const kCGLOGLPVersion_GL4_Core: CGLPixelFormatAttribute = 0x4100;
 
-static OPENGL_FRAMEWORK_IDENTIFIER: &'static str = "com.apple.opengl";
+static OPENGL_FRAMEWORK_IDENTIFIER: &str = "com.apple.opengl";
 
 thread_local! {
     #[doc(hidden)]

--- a/surfman/src/platform/macos/system/device.rs
+++ b/surfman/src/platform/macos/system/device.rs
@@ -42,7 +42,8 @@ impl Device {
     pub fn native_device(&self) -> NativeDevice {
         NativeDevice(
             MetalDevice::all()
-                .into_iter().find(|device| device.is_low_power() == self.adapter.is_low_power)
+                .into_iter()
+                .find(|device| device.is_low_power() == self.adapter.is_low_power)
                 .expect("No Metal device found!"),
         )
     }

--- a/surfman/src/platform/macos/system/device.rs
+++ b/surfman/src/platform/macos/system/device.rs
@@ -42,9 +42,7 @@ impl Device {
     pub fn native_device(&self) -> NativeDevice {
         NativeDevice(
             MetalDevice::all()
-                .into_iter()
-                .filter(|device| device.is_low_power() == self.adapter.is_low_power)
-                .next()
+                .into_iter().find(|device| device.is_low_power() == self.adapter.is_low_power)
                 .expect("No Metal device found!"),
         )
     }

--- a/surfman/src/platform/macos/system/surface.rs
+++ b/surfman/src/platform/macos/system/surface.rs
@@ -174,7 +174,7 @@ impl Device {
         surface_access: SurfaceAccess,
         native_widget: &NativeWidget,
     ) -> ViewInfo {
-        let front_surface = self.create_io_surface(&size, surface_access);
+        let front_surface = self.create_io_surface(size, surface_access);
 
         let window: id = msg_send![native_widget.view.0, window];
         let device_description: CFDictionary<CFString, CFNumber> =

--- a/surfman/src/tests.rs
+++ b/surfman/src/tests.rs
@@ -56,7 +56,6 @@ pub fn test_device_creation() {
         Ok(_) => {}
         Err(Error::RequiredExtensionUnavailable) => {
             // Can't run these tests on this hardware.
-            return;
         }
         Err(err) => panic!("Failed to create device: {:?}", err),
     }

--- a/surfman/src/tests.rs
+++ b/surfman/src/tests.rs
@@ -868,7 +868,7 @@ pub fn test_get_native_context() {
 fn bind_context_fbo(gl: &Gl, device: &Device, context: &Context) {
     unsafe {
         gl.BindFramebuffer(gl::FRAMEBUFFER, context_fbo(device, context));
-        check_gl(&gl);
+        check_gl(gl);
     }
 }
 
@@ -883,7 +883,7 @@ fn context_fbo(device: &Device, context: &Context) -> GLuint {
 fn make_surface(device: &mut Device, context: &Context) -> Surface {
     device
         .create_surface(
-            &context,
+            context,
             SurfaceAccess::GPUOnly,
             SurfaceType::Generic {
                 size: Size2D::new(640, 480),
@@ -918,9 +918,9 @@ fn make_fbo(gl: &Gl, texture_target: GLenum, texture: GLuint) -> GLuint {
     unsafe {
         let mut framebuffer_object = 0;
         gl.GenFramebuffers(1, &mut framebuffer_object);
-        check_gl(&gl);
+        check_gl(gl);
         gl.BindFramebuffer(gl::FRAMEBUFFER, framebuffer_object);
-        check_gl(&gl);
+        check_gl(gl);
         gl.FramebufferTexture2D(
             gl::FRAMEBUFFER,
             gl::COLOR_ATTACHMENT0,
@@ -928,7 +928,7 @@ fn make_fbo(gl: &Gl, texture_target: GLenum, texture: GLuint) -> GLuint {
             texture,
             0,
         );
-        check_gl(&gl);
+        check_gl(gl);
         assert_eq!(
             gl.CheckFramebufferStatus(gl::FRAMEBUFFER),
             gl::FRAMEBUFFER_COMPLETE

--- a/surfman/src/tests.rs
+++ b/surfman/src/tests.rs
@@ -76,7 +76,6 @@ pub fn test_device_accessors() {
     };
     drop(device.connection());
     drop(device.adapter());
-    drop(device.gl_api());
 }
 
 // Tests that all combinations of flags result in the creation of valid context descriptors and


### PR DESCRIPTION
Each lint was fixed in an individual commit, for easier review.

After this PR clippy is warning free when run on surfman, examples are excluded and the following lints are allowed:
- clippy::missing_safety_doc
- clippy::unnecessary_cast 
- clippy::result_large_err 
- clippy::mismatched_target_os
- clippy::unnecessary_mut_passed 
- clippy::drop_non_drop


