### PR TITLE
Add initial support for OpenHarmony

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,9 @@ jobs:
           - os: windows-latest
             target: "aarch64-pc-windows-msvc"
             rust: stable
+          - os: ubuntu-22.04
+            target: "aarch64-unknown-linux-ohos"
+            rust: beta  # Rust 1.78 is the first version where `-ohos` is tier2
     steps:
     - uses: actions/checkout@v4
     - name: Install deps on linux

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
         sudo apt update
         sudo apt install gcc libxxf86vm-dev libosmesa6-dev libgles2-mesa-dev -y
     - name: Install rust
+      id: toolchain
       uses: dtolnay/rust-toolchain@master
       with:
           toolchain: ${{ matrix.rust }}
@@ -59,20 +60,20 @@ jobs:
       if: matrix.target != 'default' && startsWith(matrix.target, 'aarch64-uwp-windows-msvc') != true
       run: |
         cd surfman
-        rustup target add ${{ matrix.target }}
-        cargo build --verbose ${{ matrix.features }} --target=${{ matrix.target }}
+        rustup +${{steps.toolchain.outputs.name}} target add ${{ matrix.target }}
+        cargo +${{steps.toolchain.outputs.name}} build --verbose ${{ matrix.features }} --target=${{ matrix.target }}
     - name: Build
       if: matrix.target == 'default'
       run: |
         cd surfman
-        cargo build --verbose ${{ matrix.features }}
+        cargo +${{steps.toolchain.outputs.name}} build --verbose ${{ matrix.features }}
     - name: Build Windows
       if: startsWith(matrix.target, 'aarch64-uwp-windows-msvc')
       shell: cmd
       run: |
         cd surfman
-        rustup component add rust-src --target=aarch64-uwp-windows-msvc
-        cargo build -Z build-std --verbose --target=aarch64-uwp-windows-msvc
+        rustup +${{steps.toolchain.outputs.name}} component add rust-src --target=aarch64-uwp-windows-msvc
+        cargo +${{steps.toolchain.outputs.name}} build -Z build-std --verbose --target=aarch64-uwp-windows-msvc
   Format:
     name: Run `rustfmt`
     runs-on: ubuntu-latest

--- a/surfman/Cargo.toml
+++ b/surfman/Cargo.toml
@@ -60,11 +60,11 @@ mach2 = "0.4"
 metal = "0.24"
 objc = "0.2"
 
-[target.'cfg(all(unix, not(any(target_os = "macos", target_os = "android"))))'.dependencies.wayland-sys]
+[target.'cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_env = "ohos"))))'.dependencies.wayland-sys]
 version = "0.30"
 features = ["client", "dlopen", "egl"]
 
-[target.'cfg(all(unix, not(any(target_os = "macos", target_os = "android"))))'.dependencies.x11]
+[target.'cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_env = "ohos"))))'.dependencies.x11]
 version = "2.3.0"
 features = ["xlib"]
 optional = true

--- a/surfman/build.rs
+++ b/surfman/build.rs
@@ -15,8 +15,9 @@ fn main() {
         windows: { target_os = "windows" },
         macos: { target_os = "macos" },
         android: { target_os = "android" },
+        ohos: { target_env = "ohos" },
         // TODO: is `target_os = "linux"` the same as the following check?
-        linux: { all(unix, not(any(macos, android))) },
+        linux: { all(unix, not(any(macos, android, ohos))) },
 
         // Features:
         // Here we collect the features that are only valid on certain platforms and
@@ -31,11 +32,13 @@ fn main() {
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target_family = env::var("CARGO_CFG_TARGET_FAMILY").ok();
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
     let dest = PathBuf::from(&env::var("OUT_DIR").unwrap());
 
     // Generate EGL bindings.
     if target_os == "android"
         || (target_os == "windows" && cfg!(feature = "sm-angle"))
+        || target_env == "ohos"
         || target_family.as_ref().map_or(false, |f| f == "unix")
     {
         let mut file = File::create(dest.join("egl_bindings.rs")).unwrap();
@@ -44,7 +47,7 @@ fn main() {
     }
 
     // Generate GL bindings.
-    if target_os == "android" {
+    if target_os == "android" || target_env == "ohos" {
         let mut file = File::create(dest.join("gl_bindings.rs")).unwrap();
         let registry = Registry::new(Api::Gles2, (3, 0), Profile::Core, Fallbacks::All, []);
         registry.write_bindings(StructGenerator, &mut file).unwrap();

--- a/surfman/src/context.rs
+++ b/surfman/src/context.rs
@@ -72,12 +72,12 @@ impl ContextAttributes {
     }
 }
 
-#[cfg(target_os = "android")]
+#[cfg(any(target_os = "android", target_env = "ohos"))]
 pub(crate) fn current_context_uses_compatibility_profile(_gl: &Gl) -> bool {
     false
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_env = "ohos")))]
 #[allow(dead_code)]
 pub(crate) fn current_context_uses_compatibility_profile(gl: &Gl) -> bool {
     unsafe {

--- a/surfman/src/lib.rs
+++ b/surfman/src/lib.rs
@@ -55,9 +55,9 @@ pub use crate::surface::{SurfaceAccess, SurfaceID, SurfaceInfo, SurfaceType, Sys
 
 pub mod macros;
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_env = "ohos")))]
 pub(crate) use crate::gl::Gl;
-#[cfg(target_os = "android")]
+#[cfg(any(target_os = "android", target_env = "ohos"))]
 pub(crate) use crate::gl::Gles2 as Gl;
 
 mod gl_utils;
@@ -70,6 +70,7 @@ mod gl {
 
 #[cfg(any(
     target_os = "android",
+    target_env = "ohos",
     all(target_os = "windows", feature = "sm-angle"),
     unix
 ))]

--- a/surfman/src/platform/generic/mod.rs
+++ b/surfman/src/platform/generic/mod.rs
@@ -2,7 +2,7 @@
 //
 //! Backends that are not specific to any operating system.
 
-#[cfg(any(android, angle, linux))]
+#[cfg(any(android, angle, linux, ohos))]
 pub(crate) mod egl;
 
 pub mod multi;

--- a/surfman/src/platform/mod.rs
+++ b/surfman/src/platform/mod.rs
@@ -9,6 +9,11 @@ pub mod android;
 #[cfg(android)]
 pub use android as default;
 
+#[cfg(ohos)]
+pub mod ohos;
+#[cfg(ohos)]
+pub use ohos as default;
+
 #[cfg(macos)]
 pub mod macos;
 #[cfg(macos)]

--- a/surfman/src/platform/ohos/connection.rs
+++ b/surfman/src/platform/ohos/connection.rs
@@ -1,0 +1,160 @@
+// surfman/surfman/src/platform/ohos/connection.rs
+//
+//! A no-op connection for OpenHarmony OS.
+
+use super::device::{Adapter, Device, NativeDevice};
+use super::surface::NativeWidget;
+use crate::Error;
+use crate::GLApi;
+
+use euclid::default::Size2D;
+
+use std::os::raw::c_void;
+
+/// A connection to the display server.
+#[derive(Clone)]
+pub struct Connection;
+
+/// An empty placeholder for native connections.
+#[derive(Clone)]
+pub struct NativeConnection;
+
+impl Connection {
+    /// Connects to the default display.
+    #[inline]
+    pub fn new() -> Result<Connection, Error> {
+        Ok(Connection)
+    }
+
+    /// An alias for `Connection::new()`, present for consistency with other backends.
+    #[inline]
+    pub unsafe fn from_native_connection(_: NativeConnection) -> Result<Connection, Error> {
+        Connection::new()
+    }
+
+    /// Returns the underlying native connection.
+    #[inline]
+    pub fn native_connection(&self) -> NativeConnection {
+        NativeConnection
+    }
+
+    /// Returns the OpenGL API flavor that this connection supports (OpenGL or OpenGL ES).
+    #[inline]
+    pub fn gl_api(&self) -> GLApi {
+        GLApi::GLES
+    }
+
+    /// Returns the "best" adapter on this system.
+    ///
+    /// This is an alias for `Connection::create_hardware_adapter()`.
+    #[inline]
+    pub fn create_adapter(&self) -> Result<Adapter, Error> {
+        self.create_hardware_adapter()
+    }
+
+    /// Returns the "best" adapter on this system, preferring high-performance hardware adapters.
+    #[inline]
+    pub fn create_hardware_adapter(&self) -> Result<Adapter, Error> {
+        Ok(Adapter)
+    }
+
+    /// Returns the "best" adapter on this system, preferring low-power hardware adapters.
+    #[inline]
+    pub fn create_low_power_adapter(&self) -> Result<Adapter, Error> {
+        Ok(Adapter)
+    }
+
+    /// Returns the "best" adapter on this system, preferring software adapters.
+    #[inline]
+    pub fn create_software_adapter(&self) -> Result<Adapter, Error> {
+        Ok(Adapter)
+    }
+
+    /// Opens the hardware device corresponding to the given adapter.
+    ///
+    /// Device handles are local to a single thread.
+    #[inline]
+    pub fn create_device(&self, _: &Adapter) -> Result<Device, Error> {
+        Device::new()
+    }
+
+    /// Wraps an OpenHarmony `EGLDisplay` in a device and returns it.
+    ///
+    /// The underlying `EGLDisplay` is not retained, as there is no way to do this in the EGL API.
+    /// Therefore, it is the caller's responsibility to keep it alive as long as this `Device`
+    /// remains alive.
+    #[inline]
+    pub unsafe fn create_device_from_native_device(
+        &self,
+        native_device: NativeDevice,
+    ) -> Result<Device, Error> {
+        Ok(Device {
+            egl_display: native_device.0,
+            display_is_owned: false,
+        })
+    }
+
+    /// Opens the display connection corresponding to the given raw display handle.
+    #[cfg(feature = "sm-raw-window-handle-05")]
+    pub fn from_raw_display_handle(_: rwh_05::RawDisplayHandle) -> Result<Connection, Error> {
+        Err(Error::UnsupportedOnThisPlatform)
+    }
+
+    /// Opens the display connection corresponding to the given `DisplayHandle`.
+    #[cfg(feature = "sm-raw-window-handle-06")]
+    pub fn from_display_handle(_: rwh_06::DisplayHandle) -> Result<Connection, Error> {
+        Ok(Connection)
+    }
+
+    /// Create a native widget from a raw pointer
+    pub unsafe fn create_native_widget_from_ptr(
+        &self,
+        raw: *mut c_void,
+        _size: Size2D<i32>,
+    ) -> NativeWidget {
+        NativeWidget {
+            native_window: raw.cast(),
+        }
+    }
+
+    /// Create a native widget type from the given `RawWindowHandle`.
+    #[cfg(feature = "sm-raw-window-handle-05")]
+    #[inline]
+    pub fn create_native_widget_from_raw_window_handle(
+        &self,
+        raw_handle: rwh_05::RawWindowHandle,
+        _size: Size2D<i32>,
+    ) -> Result<NativeWidget, Error> {
+        Err(Error::UnsupportedOnThisPlatform)
+    }
+
+    /// Create a native widget type from the given `WindowHandle`.
+    #[cfg(feature = "sm-raw-window-handle-06")]
+    #[inline]
+    pub fn create_native_widget_from_window_handle(
+        &self,
+        _handle: rwh_06::WindowHandle,
+        _size: Size2D<i32>,
+    ) -> Result<NativeWidget, Error> {
+        // Requires: https://github.com/rust-windowing/raw-window-handle/pull/164
+        Err(Error::Unimplemented)
+        //     use rwh_06::RawWindowHandle::OhosNdk;
+        //
+        //     match handle.as_raw() {
+        //         OhosNdk(handle) => Ok(NativeWidget {
+        //             native_window: handle.native_window.as_ptr().cast(),
+        //         }),
+        //         _ => Err(Error::IncompatibleNativeWidget),
+        //     }
+    }
+}
+
+impl NativeConnection {
+    /// Creates a native connection.
+    ///
+    /// This is a no-op method present for consistency with other backends.
+    #[inline]
+    pub fn current() -> Result<NativeConnection, Error> {
+        Ok(NativeConnection)
+    }
+}

--- a/surfman/src/platform/ohos/context.rs
+++ b/surfman/src/platform/ohos/context.rs
@@ -1,0 +1,374 @@
+// surfman/surfman/src/platform/ohos/context.rs
+//
+//! OpenGL rendering contexts.
+
+use super::device::Device;
+use super::surface::{Surface, SurfaceObjects};
+use crate::context::{ContextID, CREATE_CONTEXT_MUTEX};
+use crate::egl;
+use crate::egl::types::{EGLConfig, EGLContext, EGLSurface, EGLint};
+use crate::platform::generic::egl::context::{self, CurrentContextGuard};
+use crate::platform::generic::egl::device::EGL_FUNCTIONS;
+use crate::platform::generic::egl::error::ToWindowingApiError;
+use crate::platform::generic::egl::surface::ExternalEGLSurfaces;
+use crate::surface::Framebuffer;
+use crate::{ContextAttributes, Error, Gl, SurfaceInfo};
+
+use std::mem;
+use std::os::raw::c_void;
+use std::thread;
+
+pub use crate::platform::generic::egl::context::{ContextDescriptor, NativeContext};
+
+thread_local! {
+    #[doc(hidden)]
+    pub static GL_FUNCTIONS: Gl = Gl::load_with(context::get_proc_address);
+}
+
+/// Represents an OpenGL rendering context.
+///
+/// A context allows you to issue rendering commands to a surface. When initially created, a
+/// context has no attached surface, so rendering commands will fail or be ignored. Typically, you
+/// attach a surface to the context before rendering.
+///
+/// Contexts take ownership of the surfaces attached to them. In order to mutate a surface in any
+/// way other than rendering to it (e.g. presenting it to a window, which causes a buffer swap), it
+/// must first be detached from its context. Each surface is associated with a single context upon
+/// creation and may not be rendered to from any other context. However, you can wrap a surface in
+/// a surface texture, which allows the surface to be read from another context.
+///
+/// OpenGL objects may not be shared across contexts directly, but surface textures effectively
+/// allow for sharing of texture data. Contexts are local to a single thread and device.
+///
+/// A context must be explicitly destroyed with `destroy_context()`, or a panic will occur.
+pub struct Context {
+    pub(crate) egl_context: EGLContext,
+    pub(crate) id: ContextID,
+    pub(crate) pbuffer: EGLSurface,
+    framebuffer: Framebuffer<Surface, ExternalEGLSurfaces>,
+    context_is_owned: bool,
+}
+
+impl Drop for Context {
+    #[inline]
+    fn drop(&mut self) {
+        if self.egl_context != egl::NO_CONTEXT && !thread::panicking() {
+            panic!("Contexts must be destroyed explicitly with `destroy_context`!")
+        }
+    }
+}
+
+impl Device {
+    /// Creates a context descriptor with the given attributes.
+    ///
+    /// Context descriptors are local to this device.
+    #[inline]
+    pub fn create_context_descriptor(
+        &self,
+        attributes: &ContextAttributes,
+    ) -> Result<ContextDescriptor, Error> {
+        unsafe {
+            ContextDescriptor::new(
+                self.egl_display,
+                attributes,
+                &[
+                    egl::COLOR_BUFFER_TYPE as EGLint,
+                    egl::RGB_BUFFER as EGLint,
+                    egl::SURFACE_TYPE as EGLint,
+                    egl::PBUFFER_BIT as EGLint,
+                    egl::RENDERABLE_TYPE as EGLint,
+                    egl::OPENGL_ES2_BIT as EGLint,
+                ],
+            )
+        }
+    }
+
+    /// Creates a new OpenGL context.
+    ///
+    /// The context initially has no surface attached. Until a surface is bound to it, rendering
+    /// commands will fail or have no effect.
+    pub fn create_context(
+        &mut self,
+        descriptor: &ContextDescriptor,
+        share_with: Option<&Context>,
+    ) -> Result<Context, Error> {
+        let mut next_context_id = CREATE_CONTEXT_MUTEX.lock().unwrap();
+
+        let egl_display = self.egl_display;
+
+        unsafe {
+            // Create the EGL context.
+            let gl_api = self.gl_api();
+            let egl_context = context::create_context(
+                egl_display,
+                descriptor,
+                share_with.map_or(egl::NO_CONTEXT, |ctx| ctx.egl_context),
+                gl_api,
+            )?;
+
+            // Create a dummy pbuffer.
+            let pbuffer = context::create_dummy_pbuffer(egl_display, egl_context);
+
+            // Wrap up the EGL context.
+            let context = Context {
+                egl_context,
+                id: *next_context_id,
+                pbuffer,
+                framebuffer: Framebuffer::None,
+                context_is_owned: true,
+            };
+            next_context_id.0 += 1;
+            Ok(context)
+        }
+    }
+
+    /// Wraps a native `EGLContext` in a context object.
+    ///
+    /// The underlying `EGLContext` is not retained, as there is no way to do this in the EGL API.
+    /// Therefore, it is the caller's responsibility to keep it alive as long as this `Context`
+    /// remains alive.
+    pub unsafe fn create_context_from_native_context(
+        &self,
+        native_context: NativeContext,
+    ) -> Result<Context, Error> {
+        let mut next_context_id = CREATE_CONTEXT_MUTEX.lock().unwrap();
+
+        // Create a dummy pbuffer.
+        let pbuffer = context::create_dummy_pbuffer(self.egl_display, native_context.egl_context);
+
+        // Create the context.
+        let context = Context {
+            egl_context: native_context.egl_context,
+            id: *next_context_id,
+            pbuffer,
+            framebuffer: Framebuffer::External(ExternalEGLSurfaces {
+                draw: native_context.egl_draw_surface,
+                read: native_context.egl_read_surface,
+            }),
+            context_is_owned: false,
+        };
+        next_context_id.0 += 1;
+
+        Ok(context)
+    }
+
+    /// Destroys a context.
+    ///
+    /// The context must have been created on this device.
+    pub fn destroy_context(&self, context: &mut Context) -> Result<(), Error> {
+        if context.egl_context == egl::NO_CONTEXT {
+            return Ok(());
+        }
+
+        unsafe {
+            if let Framebuffer::Surface(mut target) =
+                mem::replace(&mut context.framebuffer, Framebuffer::None)
+            {
+                self.destroy_surface(context, &mut target)?;
+            }
+
+            EGL_FUNCTIONS.with(|egl| {
+                let result = egl.DestroySurface(self.egl_display, context.pbuffer);
+                assert_ne!(result, egl::FALSE);
+                context.pbuffer = egl::NO_SURFACE;
+
+                egl.MakeCurrent(
+                    self.egl_display,
+                    egl::NO_SURFACE,
+                    egl::NO_SURFACE,
+                    egl::NO_CONTEXT,
+                );
+
+                if context.context_is_owned {
+                    let result = egl.DestroyContext(self.egl_display, context.egl_context);
+                    assert_ne!(result, egl::FALSE);
+                }
+
+                context.egl_context = egl::NO_CONTEXT;
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Returns the descriptor that this context was created with.
+    pub fn context_descriptor(&self, context: &Context) -> ContextDescriptor {
+        GL_FUNCTIONS.with(|gl| unsafe {
+            ContextDescriptor::from_egl_context(gl, self.egl_display, context.egl_context)
+        })
+    }
+
+    /// Makes the context the current OpenGL context for this thread.
+    ///
+    /// After calling this function, it is valid to use OpenGL rendering commands.
+    pub fn make_context_current(&self, context: &Context) -> Result<(), Error> {
+        unsafe {
+            let egl_display = self.egl_display;
+            let egl_context = context.egl_context;
+
+            let (egl_draw_surface, egl_read_surface) = match context.framebuffer {
+                Framebuffer::Surface(Surface {
+                    objects: SurfaceObjects::Window { egl_surface },
+                    ..
+                }) => (egl_surface, egl_surface),
+                Framebuffer::External(ExternalEGLSurfaces { draw, read }) => (draw, read),
+                Framebuffer::None => (context.pbuffer, context.pbuffer),
+            };
+
+            EGL_FUNCTIONS.with(|egl| {
+                let result =
+                    egl.MakeCurrent(egl_display, egl_draw_surface, egl_read_surface, egl_context);
+                if result == egl::FALSE {
+                    let err = egl.GetError().to_windowing_api_error();
+                    return Err(Error::MakeCurrentFailed(err));
+                }
+                Ok(())
+            })
+        }
+    }
+
+    /// Removes the current OpenGL context from this thread.
+    ///
+    /// After calling this function, OpenGL rendering commands will fail until a new context is
+    /// made current.
+    pub fn make_no_context_current(&self) -> Result<(), Error> {
+        unsafe { context::make_no_context_current(self.egl_display) }
+    }
+
+    /// Attaches a surface to a context for rendering.
+    ///
+    /// This function takes ownership of the surface. The surface must have been created with this
+    /// context, or an `IncompatibleSurface` error is returned.
+    ///
+    /// If this function is called with a surface already bound, a `SurfaceAlreadyBound` error is
+    /// returned. To avoid this error, first unbind the existing surface with
+    /// `unbind_surface_from_context`.
+    ///
+    /// If an error is returned, the surface is returned alongside it.
+    pub fn bind_surface_to_context(
+        &self,
+        context: &mut Context,
+        new_surface: Surface,
+    ) -> Result<(), (Error, Surface)> {
+        if context.id != new_surface.context_id {
+            return Err((Error::IncompatibleSurface, new_surface));
+        }
+
+        match context.framebuffer {
+            Framebuffer::External { .. } => return Err((Error::ExternalRenderTarget, new_surface)),
+            Framebuffer::Surface(_) => return Err((Error::SurfaceAlreadyBound, new_surface)),
+            Framebuffer::None => {}
+        }
+
+        context.framebuffer = Framebuffer::Surface(new_surface);
+        Ok(())
+    }
+
+    /// Removes and returns any attached surface from this context.
+    ///
+    /// Any pending OpenGL commands targeting this surface will be automatically flushed, so the
+    /// surface is safe to read from immediately when this function returns.
+    pub fn unbind_surface_from_context(
+        &self,
+        context: &mut Context,
+    ) -> Result<Option<Surface>, Error> {
+        match context.framebuffer {
+            Framebuffer::External { .. } => return Err(Error::ExternalRenderTarget),
+            Framebuffer::None => return Ok(None),
+            Framebuffer::Surface(_) => {}
+        }
+
+        // Make sure all changes are synchronized.
+        //
+        // FIXME(pcwalton): Is this necessary?
+        let _guard = self.temporarily_make_context_current(context)?;
+        GL_FUNCTIONS.with(|gl| unsafe {
+            gl.Flush();
+        });
+
+        match mem::replace(&mut context.framebuffer, Framebuffer::None) {
+            Framebuffer::Surface(surface) => return Ok(Some(surface)),
+            Framebuffer::External { .. } | Framebuffer::None => unreachable!(),
+        }
+    }
+
+    /// Returns the attributes that the context descriptor was created with.
+    pub fn context_descriptor_attributes(
+        &self,
+        context_descriptor: &ContextDescriptor,
+    ) -> ContextAttributes {
+        unsafe { context_descriptor.attributes(self.egl_display) }
+    }
+
+    /// Fetches the address of an OpenGL function associated with this context.
+    ///
+    /// OpenGL functions are local to a context. You should not use OpenGL functions on one context
+    /// with any other context.
+    ///
+    /// This method is typically used with a function like `gl::load_with()` from the `gl` crate to
+    /// load OpenGL function pointers.
+    #[inline]
+    pub fn get_proc_address(&self, _: &Context, symbol_name: &str) -> *const c_void {
+        context::get_proc_address(symbol_name)
+    }
+
+    pub(crate) fn context_to_egl_config(&self, context: &Context) -> EGLConfig {
+        unsafe {
+            context::egl_config_from_id(
+                self.egl_display,
+                context::get_context_attr(
+                    self.egl_display,
+                    context.egl_context,
+                    egl::CONFIG_ID as EGLint,
+                ),
+            )
+        }
+    }
+
+    pub(crate) fn temporarily_make_context_current(
+        &self,
+        context: &Context,
+    ) -> Result<CurrentContextGuard, Error> {
+        let guard = CurrentContextGuard::new();
+        self.make_context_current(context)?;
+        Ok(guard)
+    }
+
+    /// Returns a unique ID representing a context.
+    ///
+    /// This ID is unique to all currently-allocated contexts. If you destroy a context and create
+    /// a new one, the new context might have the same ID as the destroyed one.
+    #[inline]
+    pub fn context_id(&self, context: &Context) -> ContextID {
+        context.id
+    }
+
+    /// Returns various information about the surface attached to a context.
+    ///
+    /// This includes, most notably, the OpenGL framebuffer object needed to render to the surface.
+    pub fn context_surface_info(&self, context: &Context) -> Result<Option<SurfaceInfo>, Error> {
+        match context.framebuffer {
+            Framebuffer::None => Ok(None),
+            Framebuffer::External { .. } => Err(Error::ExternalRenderTarget),
+            Framebuffer::Surface(ref surface) => Ok(Some(self.surface_info(surface))),
+        }
+    }
+
+    /// Given a context, returns its underlying EGL context and attached surfaces.
+    pub fn native_context(&self, context: &Context) -> NativeContext {
+        let (egl_draw_surface, egl_read_surface) = match context.framebuffer {
+            Framebuffer::Surface(Surface {
+                objects: SurfaceObjects::Window { egl_surface },
+                ..
+            }) => (egl_surface, egl_surface),
+            Framebuffer::External(ExternalEGLSurfaces { draw, read }) => (draw, read),
+            Framebuffer::None => (context.pbuffer, context.pbuffer),
+        };
+
+        NativeContext {
+            egl_context: context.egl_context,
+            egl_draw_surface,
+            egl_read_surface,
+        }
+    }
+}

--- a/surfman/src/platform/ohos/device.rs
+++ b/surfman/src/platform/ohos/device.rs
@@ -1,0 +1,95 @@
+// surfman/surfman/src/platform/ohos/device.rs
+//
+//! A thread-local handle to the device.
+
+use super::connection::Connection;
+use crate::egl;
+use crate::egl::types::EGLDisplay;
+use crate::platform::generic::egl::device::EGL_FUNCTIONS;
+use crate::{Error, GLApi};
+
+/// Represents a hardware display adapter that can be used for rendering (including the CPU).
+///
+/// Adapters can be sent between threads. To render with an adapter, open a thread-local `Device`.
+#[derive(Clone, Debug)]
+pub struct Adapter;
+
+/// A thread-local handle to a device.
+///
+/// Devices contain most of the relevant surface management methods.
+pub struct Device {
+    pub(crate) egl_display: EGLDisplay,
+    pub(crate) display_is_owned: bool,
+}
+
+/// Wrapper for an `EGLDisplay`.
+#[derive(Clone, Copy)]
+pub struct NativeDevice(pub EGLDisplay);
+
+impl Drop for Device {
+    fn drop(&mut self) {
+        EGL_FUNCTIONS.with(|egl| unsafe {
+            if !self.display_is_owned {
+                return;
+            }
+            let result = egl.Terminate(self.egl_display);
+            assert_ne!(result, egl::FALSE);
+            self.egl_display = egl::NO_DISPLAY;
+        })
+    }
+}
+
+impl NativeDevice {
+    /// Returns the current EGL display.
+    ///
+    /// If there is no current EGL display, `egl::NO_DISPLAY` is returned.
+    pub fn current() -> NativeDevice {
+        EGL_FUNCTIONS.with(|egl| unsafe { NativeDevice(egl.GetCurrentDisplay()) })
+    }
+}
+
+impl Device {
+    #[inline]
+    pub(crate) fn new() -> Result<Device, Error> {
+        EGL_FUNCTIONS.with(|egl| {
+            unsafe {
+                let egl_display = egl.GetDisplay(egl::DEFAULT_DISPLAY);
+                assert_ne!(egl_display, egl::NO_DISPLAY);
+
+                // I don't think this should ever fail.
+                let (mut major_version, mut minor_version) = (0, 0);
+                let result = egl.Initialize(egl_display, &mut major_version, &mut minor_version);
+                assert_ne!(result, egl::FALSE);
+
+                Ok(Device {
+                    egl_display,
+                    display_is_owned: true,
+                })
+            }
+        })
+    }
+
+    /// Returns the EGL display corresponding to this device.
+    #[inline]
+    pub fn native_device(&self) -> NativeDevice {
+        NativeDevice(self.egl_display)
+    }
+
+    /// Returns the display server connection that this device was created with.
+    #[inline]
+    pub fn connection(&self) -> Connection {
+        Connection
+    }
+
+    /// Returns the adapter that this device was created with.
+    #[inline]
+    pub fn adapter(&self) -> Adapter {
+        Adapter
+    }
+
+    /// Returns the OpenGL API flavor that this device supports (OpenGL or OpenGL ES).
+    #[inline]
+    pub fn gl_api(&self) -> GLApi {
+        GLApi::GLES
+    }
+}

--- a/surfman/src/platform/ohos/ffi.rs
+++ b/surfman/src/platform/ohos/ffi.rs
@@ -1,0 +1,37 @@
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+#![allow(non_snake_case)]
+#![allow(unused)]
+
+#[repr(C)]
+pub struct NativeWindow {
+    _unused: [u8; 0],
+}
+
+pub type OHNativeWindow = NativeWindow;
+
+#[repr(transparent)]
+pub(crate) struct NativeWindowOperation(core::ffi::c_int);
+
+impl NativeWindowOperation {
+    pub const GET_BUFFER_GEOMETRY: Self = Self(1);
+}
+
+/// According to the [native window guidelines], users need to link against
+/// both the NDK and `native_window`.
+/// [native window guidelines]: <https://gitee.com/openharmony/docs/blob/master/en/application-dev/graphics/native-window-guidelines.md>
+#[link(name = "native_window")]
+#[link(name = "ace_ndk.z")]
+extern "C" {
+    /// Sets or obtains the attributes of a native window
+    ///
+    /// Can be used to query information like height and width.
+    /// See the official [Documentation] for detailed usage information.
+    ///
+    /// [Documentation]: <https://gitee.com/openharmony/docs/blob/master/en/application-dev/reference/apis-arkgraphics2d/_native_window.md>
+    pub(crate) fn OH_NativeWindow_NativeWindowHandleOpt(
+        window: *mut OHNativeWindow,
+        code: NativeWindowOperation,
+        ...
+    ) -> i32;
+}

--- a/surfman/src/platform/ohos/mod.rs
+++ b/surfman/src/platform/ohos/mod.rs
@@ -1,0 +1,17 @@
+// surfman/surfman/src/platform/ohos/mod.rs
+//
+//! Bindings to EGL on OpenHarmony OS.
+
+pub mod connection;
+pub mod context;
+pub mod device;
+pub mod surface;
+
+mod ffi;
+
+#[path = "../../implementation/mod.rs"]
+mod implementation;
+
+#[cfg(feature = "sm-test")]
+#[path = "../../tests.rs"]
+pub mod tests;

--- a/surfman/src/platform/ohos/surface.rs
+++ b/surfman/src/platform/ohos/surface.rs
@@ -1,0 +1,343 @@
+// surfman/surfman/src/platform/ohos/surface.rs
+//
+//! Surface management for OpenHarmony OS using EGL.
+
+use std::fmt::{self, Debug, Formatter};
+use std::marker::PhantomData;
+use std::os::raw::c_void;
+use std::ptr;
+use std::thread;
+
+use euclid::default::Size2D;
+use log::info;
+
+use crate::context::ContextID;
+use crate::egl;
+use crate::egl::types::EGLSurface;
+use crate::gl;
+use crate::gl::types::{GLenum, GLuint};
+pub use crate::platform::generic::egl::context::ContextDescriptor;
+use crate::platform::generic::egl::device::EGL_FUNCTIONS;
+use crate::platform::generic::egl::ffi::EGLImageKHR;
+use crate::platform::generic::egl::ffi::EGL_EXTENSION_FUNCTIONS;
+use crate::platform::generic::egl::ffi::EGL_NO_IMAGE_KHR;
+use crate::{Error, SurfaceAccess, SurfaceID, SurfaceInfo, SurfaceType};
+
+use super::context::{Context, GL_FUNCTIONS};
+use super::device::Device;
+use super::ffi::{NativeWindowOperation, OHNativeWindow, OH_NativeWindow_NativeWindowHandleOpt};
+
+const SURFACE_GL_TEXTURE_TARGET: GLenum = gl::TEXTURE_2D;
+
+/// Represents a hardware buffer of pixels that can be rendered to via the CPU or GPU and either
+/// displayed in a native widget or bound to a texture for reading.
+///
+/// Surfaces come in two varieties: generic and widget surfaces. Generic surfaces can be bound to a
+/// texture but cannot be displayed in a widget (without using other APIs such as Core Animation,
+/// DirectComposition, or XPRESENT). Widget surfaces are the opposite: they can be displayed in a
+/// widget but not bound to a texture.
+///
+/// Surfaces are specific to a given context and cannot be rendered to from any context other than
+/// the one they were created with. However, they can be *read* from any context on any thread (as
+/// long as that context shares the same adapter and connection), by wrapping them in a
+/// `SurfaceTexture`.
+///
+/// Depending on the platform, each surface may be internally double-buffered.
+///
+/// Surfaces must be destroyed with the `destroy_surface()` method, or a panic will occur.
+pub struct Surface {
+    pub(crate) context_id: ContextID,
+    pub(crate) size: Size2D<i32>,
+    pub(crate) objects: SurfaceObjects,
+    pub(crate) destroyed: bool,
+}
+
+/// Represents an OpenGL texture that wraps a surface.
+///
+/// Reading from the associated OpenGL texture reads from the surface. It is undefined behavior to
+/// write to such a texture (e.g. by binding it to a framebuffer and rendering to that
+/// framebuffer).
+///
+/// Surface textures are local to a context, but that context does not have to be the same context
+/// as that associated with the underlying surface. The texture must be destroyed with the
+/// `destroy_surface_texture()` method, or a panic will occur.
+pub struct SurfaceTexture {
+    pub(crate) surface: Surface,
+    pub(crate) local_egl_image: EGLImageKHR,
+    pub(crate) texture_object: GLuint,
+    pub(crate) phantom: PhantomData<*const ()>,
+}
+
+pub(crate) enum SurfaceObjects {
+    Window { egl_surface: EGLSurface },
+}
+
+unsafe impl Send for Surface {}
+
+impl Debug for Surface {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "Surface({:x})", self.id().0)
+    }
+}
+
+impl Drop for Surface {
+    fn drop(&mut self) {
+        if !self.destroyed && !thread::panicking() {
+            panic!("Should have destroyed the surface first with `destroy_surface()`!")
+        }
+    }
+}
+
+impl Debug for SurfaceTexture {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        write!(f, "SurfaceTexture({:?})", self.surface)
+    }
+}
+
+/// An OHOS native window.
+pub struct NativeWidget {
+    pub(crate) native_window: *mut OHNativeWindow,
+}
+
+impl Device {
+    /// Creates either a generic or a widget surface, depending on the supplied surface type.
+    ///
+    /// Only the given context may ever render to the surface, but generic surfaces can be wrapped
+    /// up in a `SurfaceTexture` for reading by other contexts.
+    pub fn create_surface(
+        &mut self,
+        context: &Context,
+        _: SurfaceAccess,
+        surface_type: SurfaceType<NativeWidget>,
+    ) -> Result<Surface, Error> {
+        info!("Device create_surface with Context");
+        match surface_type {
+            SurfaceType::Generic { size } => self.create_generic_surface(context, &size),
+            SurfaceType::Widget { native_widget } => unsafe {
+                self.create_window_surface(context, native_widget)
+            },
+        }
+    }
+
+    fn create_generic_surface(
+        &mut self,
+        _context: &Context,
+        _size: &Size2D<i32>,
+    ) -> Result<Surface, Error> {
+        Err(Error::Unimplemented)
+    }
+
+    unsafe fn create_window_surface(
+        &mut self,
+        context: &Context,
+        native_widget: NativeWidget,
+    ) -> Result<Surface, Error> {
+        let mut height: i32 = 0;
+        let mut width: i32 = 0;
+        // Safety: `OH_NativeWindow_NativeWindowHandleOpt` takes two output i32 pointers as
+        // variable arguments when called with `GET_BUFFER_GEOMETRY`. See the OHNativeWindow
+        // documentation for details:
+        // https://gitee.com/openharmony/docs/blob/master/en/application-dev/reference/apis-arkgraphics2d/_native_window.md
+        let result = unsafe {
+            OH_NativeWindow_NativeWindowHandleOpt(
+                native_widget.native_window,
+                NativeWindowOperation::GET_BUFFER_GEOMETRY,
+                &mut height as *mut i32,
+                &mut width as *mut i32,
+            )
+        };
+        assert_eq!(result, 0, "Failed to determine size of native window");
+        EGL_FUNCTIONS.with(|egl| {
+            let egl_surface = egl.CreateWindowSurface(
+                self.egl_display,
+                self.context_to_egl_config(context),
+                native_widget.native_window as *const c_void,
+                ptr::null(),
+            );
+            assert_ne!(egl_surface, egl::NO_SURFACE);
+
+            Ok(Surface {
+                context_id: context.id,
+                size: Size2D::new(width, height),
+                objects: SurfaceObjects::Window { egl_surface },
+                destroyed: false,
+            })
+        })
+    }
+
+    /// Creates a surface texture from an existing generic surface for use with the given context.
+    ///
+    /// The surface texture is local to the supplied context and takes ownership of the surface.
+    /// Destroying the surface texture allows you to retrieve the surface again.
+    ///
+    /// *The supplied context does not have to be the same context that the surface is associated
+    /// with.* This allows you to render to a surface in one context and sample from that surface
+    /// in another context.
+    ///
+    /// Calling this method on a widget surface returns a `WidgetAttached` error.
+    /// On OpenHarmony, currently only widget surfaces are implemented in surfman, so
+    /// this method unconditionally returns the `WidgetAttached` error.
+    pub fn create_surface_texture(
+        &self,
+        _context: &mut Context,
+        surface: Surface,
+    ) -> Result<SurfaceTexture, (Error, Surface)> {
+        Err((Error::WidgetAttached, surface))
+    }
+
+    /// Displays the contents of a widget surface on screen.
+    ///
+    /// Widget surfaces are internally double-buffered, so changes to them don't show up in their
+    /// associated widgets until this method is called.
+    ///
+    /// The supplied context must match the context the surface was created with, or an
+    /// `IncompatibleSurface` error is returned.
+    pub fn present_surface(&self, context: &Context, surface: &mut Surface) -> Result<(), Error> {
+        if context.id != surface.context_id {
+            return Err(Error::IncompatibleSurface);
+        }
+
+        EGL_FUNCTIONS.with(|egl| unsafe {
+            match surface.objects {
+                SurfaceObjects::Window { egl_surface } => {
+                    egl.SwapBuffers(self.egl_display, egl_surface);
+                    Ok(())
+                }
+            }
+        })
+    }
+
+    /// Resizes a widget surface.
+    pub fn resize_surface(
+        &self,
+        _context: &Context,
+        surface: &mut Surface,
+        size: Size2D<i32>,
+    ) -> Result<(), Error> {
+        surface.size = size;
+        Ok(())
+    }
+
+    /// Destroys a surface.
+    ///
+    /// The supplied context must be the context the surface is associated with, or this returns
+    /// an `IncompatibleSurface` error.
+    ///
+    /// You must explicitly call this method to dispose of a surface. Otherwise, a panic occurs in
+    /// the `drop` method.
+    pub fn destroy_surface(
+        &self,
+        context: &mut Context,
+        surface: &mut Surface,
+    ) -> Result<(), Error> {
+        if context.id != surface.context_id {
+            return Err(Error::IncompatibleSurface);
+        }
+
+        unsafe {
+            match surface.objects {
+                SurfaceObjects::Window {
+                    ref mut egl_surface,
+                } => EGL_FUNCTIONS.with(|egl| {
+                    egl.DestroySurface(self.egl_display, *egl_surface);
+                    *egl_surface = egl::NO_SURFACE;
+                }),
+            }
+        }
+
+        surface.destroyed = true;
+        Ok(())
+    }
+
+    /// Destroys a surface texture and returns the underlying surface.
+    ///
+    /// The supplied context must be the same context the surface texture was created with, or an
+    /// `IncompatibleSurfaceTexture` error is returned.
+    ///
+    /// All surface textures must be explicitly destroyed with this function, or a panic will
+    /// occur.
+    pub fn destroy_surface_texture(
+        &self,
+        context: &mut Context,
+        mut surface_texture: SurfaceTexture,
+    ) -> Result<Surface, (Error, SurfaceTexture)> {
+        let _guard = self.temporarily_make_context_current(context);
+        GL_FUNCTIONS.with(|gl| {
+            unsafe {
+                gl.DeleteTextures(1, &surface_texture.texture_object);
+                surface_texture.texture_object = 0;
+
+                let egl_display = self.egl_display;
+                let result = (EGL_EXTENSION_FUNCTIONS.DestroyImageKHR)(
+                    egl_display,
+                    surface_texture.local_egl_image,
+                );
+                assert_ne!(result, egl::FALSE);
+                surface_texture.local_egl_image = EGL_NO_IMAGE_KHR;
+            }
+
+            Ok(surface_texture.surface)
+        })
+    }
+
+    /// Returns a pointer to the underlying surface data for reading or writing by the CPU.
+    #[inline]
+    pub fn lock_surface_data<'s>(&self, _: &'s mut Surface) -> Result<SurfaceDataGuard<'s>, Error> {
+        error!("lock_surface_data not implemented yet for OHOS");
+        Err(Error::Unimplemented)
+    }
+
+    /// Returns the OpenGL texture target needed to read from this surface texture.
+    ///
+    /// This will be `GL_TEXTURE_2D` or `GL_TEXTURE_RECTANGLE`, depending on platform.
+    #[inline]
+    pub fn surface_gl_texture_target(&self) -> GLenum {
+        SURFACE_GL_TEXTURE_TARGET
+    }
+
+    /// Returns various information about the surface, including the framebuffer object needed to
+    /// render to this surface.
+    ///
+    /// Before rendering to a surface attached to a context, you must call `glBindFramebuffer()`
+    /// on the framebuffer object returned by this function. This framebuffer object may or not be
+    /// 0, the default framebuffer, depending on platform.
+    pub fn surface_info(&self, surface: &Surface) -> SurfaceInfo {
+        SurfaceInfo {
+            size: surface.size,
+            id: surface.id(),
+            context_id: surface.context_id,
+            framebuffer_object: match surface.objects {
+                SurfaceObjects::Window { .. } => 0,
+            },
+        }
+    }
+
+    /// Returns the OpenGL texture object containing the contents of this surface.
+    ///
+    /// It is only legal to read from, not write to, this texture object.
+    #[inline]
+    pub fn surface_texture_object(&self, surface_texture: &SurfaceTexture) -> GLuint {
+        surface_texture.texture_object
+    }
+}
+
+impl NativeWidget {
+    /// Creates a native widget type from an `OHNativeWindow`.
+    #[inline]
+    pub unsafe fn from_native_window(native_window: *mut OHNativeWindow) -> NativeWidget {
+        NativeWidget { native_window }
+    }
+}
+
+impl Surface {
+    fn id(&self) -> SurfaceID {
+        match self.objects {
+            SurfaceObjects::Window { egl_surface } => SurfaceID(egl_surface as usize),
+        }
+    }
+}
+
+/// Represents the CPU view of the pixel data of this surface.
+pub struct SurfaceDataGuard<'a> {
+    phantom: PhantomData<&'a ()>,
+}

--- a/surfman/src/tests.rs
+++ b/surfman/src/tests.rs
@@ -719,7 +719,7 @@ pub fn test_surface_texture_right_side_up() {
     }
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_env = "ohos")))]
 #[cfg_attr(not(feature = "sm-test"), test)]
 pub fn test_depth_and_stencil() {
     let connection = Connection::new().unwrap();


### PR DESCRIPTION
This adds support all the surfman APIs servo seems to be requiring on OpenHarmony.
Generic surfaces are not supported at the moment.
This patch is heavily based on the existing android implementation.
