### PR TITLE
Run unit-tests serially

### DIFF
--- a/surfman/Cargo.toml
+++ b/surfman/Cargo.toml
@@ -48,6 +48,7 @@ gl = "0.14"
 png = "0.17"
 rand = "0.8"
 winit = "0.29"
+serial_test = "3.1.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cgl = "0.3.2"

--- a/surfman/src/tests.rs
+++ b/surfman/src/tests.rs
@@ -18,6 +18,7 @@ use crate::{ContextAttributeFlags, ContextAttributes, Error, GLApi, GLVersion, G
 use crate::{SurfaceType, WindowingApiError};
 
 use euclid::default::Size2D;
+use serial_test::serial;
 use std::os::raw::c_void;
 use std::sync::mpsc;
 use std::thread;
@@ -39,6 +40,7 @@ static GL_ES_VERSIONS: [GLVersion; 4] = [
 ];
 
 #[cfg_attr(not(feature = "sm-test"), test)]
+#[serial]
 pub fn test_adapter_creation() {
     let connection = Connection::new().unwrap();
     connection.create_hardware_adapter().unwrap();
@@ -47,6 +49,7 @@ pub fn test_adapter_creation() {
 }
 
 #[cfg_attr(not(feature = "sm-test"), test)]
+#[serial]
 pub fn test_device_creation() {
     let connection = Connection::new().unwrap();
     let adapter = connection
@@ -62,6 +65,7 @@ pub fn test_device_creation() {
 }
 
 #[cfg_attr(not(feature = "sm-test"), test)]
+#[serial]
 pub fn test_device_accessors() {
     let connection = Connection::new().unwrap();
     let adapter = connection.create_low_power_adapter().unwrap();
@@ -80,6 +84,7 @@ pub fn test_device_accessors() {
 // Tests that all combinations of flags result in the creation of valid context descriptors and
 // contexts.
 #[cfg_attr(not(feature = "sm-test"), test)]
+#[serial]
 pub fn test_context_creation() {
     let connection = Connection::new().unwrap();
     let adapter = connection
@@ -159,6 +164,7 @@ pub fn test_context_creation() {
 
 // Tests that newly-created contexts are not immediately made current (issue #7).
 #[cfg_attr(not(feature = "sm-test"), test)]
+#[serial]
 pub fn test_newly_created_contexts_are_not_current() {
     let connection = Connection::new().unwrap();
     let adapter = connection
@@ -227,6 +233,7 @@ pub fn test_newly_created_contexts_are_not_current() {
 
 // Tests a simple case of one context being shared with another.
 #[cfg_attr(not(feature = "sm-test"), test)]
+#[serial]
 pub fn test_context_sharing() {
     let connection = Connection::new().unwrap();
     let adapter = connection
@@ -267,6 +274,7 @@ pub fn test_context_sharing() {
 
 // Tests that generic surfaces can be created.
 #[cfg_attr(not(feature = "sm-test"), test)]
+#[serial]
 pub fn test_generic_surface_creation() {
     let connection = Connection::new().unwrap();
     let adapter = connection
@@ -335,6 +343,7 @@ pub fn test_generic_surface_creation() {
 
 // Tests that basic GL commands work.
 #[cfg_attr(not(feature = "sm-test"), test)]
+#[serial]
 pub fn test_gl() {
     let mut env = match BasicEnvironment::new() {
         None => return,
@@ -428,6 +437,7 @@ pub fn test_gl() {
 }
 
 #[cfg_attr(not(feature = "sm-test"), test)]
+#[serial]
 pub fn test_surface_texture_blit_framebuffer() {
     let mut env = match BasicEnvironment::new() {
         None => return,
@@ -494,6 +504,7 @@ pub fn test_surface_texture_blit_framebuffer() {
 }
 
 #[cfg_attr(not(feature = "sm-test"), test)]
+#[serial]
 pub fn test_cross_device_surface_texture_blit_framebuffer() {
     let mut env = match BasicEnvironment::new() {
         None => return,
@@ -564,6 +575,7 @@ pub fn test_cross_device_surface_texture_blit_framebuffer() {
 }
 
 #[cfg_attr(not(feature = "sm-test"), test)]
+#[serial]
 pub fn test_cross_thread_surface_texture_blit_framebuffer() {
     let mut env = match BasicEnvironment::new() {
         None => return,
@@ -649,6 +661,7 @@ pub fn test_cross_thread_surface_texture_blit_framebuffer() {
 
 // Tests that surface textures are not upside-down.
 #[cfg_attr(not(feature = "sm-test"), test)]
+#[serial]
 pub fn test_surface_texture_right_side_up() {
     let mut env = match BasicEnvironment::new() {
         None => return,
@@ -721,6 +734,7 @@ pub fn test_surface_texture_right_side_up() {
 
 #[cfg(not(target_os = "android"))]
 #[cfg_attr(not(feature = "sm-test"), test)]
+#[serial]
 pub fn test_depth_and_stencil() {
     let connection = Connection::new().unwrap();
     let adapter = connection
@@ -782,7 +796,11 @@ pub fn test_depth_and_stencil() {
             gl::FLOAT,
             (&mut depth_value) as *mut f32 as *mut c_void,
         );
-        assert!(approx_eq(depth_value, 0.5));
+        assert!(
+            approx_eq(depth_value, 0.5),
+            "actual depth value was {}, but expected 0.5",
+            depth_value
+        );
     }
 
     device.destroy_context(&mut depth_context).unwrap();
@@ -838,6 +856,7 @@ pub fn test_depth_and_stencil() {
 // Make sure that the current native context can be fetched and that they can be correctly wrapped
 // in `surfman` contexts.
 #[cfg_attr(not(feature = "sm-test"), test)]
+#[serial]
 pub fn test_get_native_context() {
     let mut env = match BasicEnvironment::new() {
         None => return,


### PR DESCRIPTION
This fixes random test failures due to tests interfering with each other.
Note: I'm not familiar with what the `sm-test` feature does and it's not documented, so I'm not sure I need to wrap the `#[serial]`  in `[cfg_attr()]` or not.

Fixes #288