### PR TITLE
Fix clippy lint `mismatched_target_os`

### DIFF
--- a/surfman/build.rs
+++ b/surfman/build.rs
@@ -12,21 +12,26 @@ fn main() {
     // Setup aliases for #[cfg] checks
     cfg_aliases! {
         // Platforms
-        windows: { target_os = "windows" },
-        macos: { target_os = "macos" },
-        android: { target_os = "android" },
-        // TODO: is `target_os = "linux"` the same as the following check?
-        linux: { all(unix, not(any(macos, android))) },
+        android_platform: { target_os = "android" },
+        web_platform: { all(target_family = "wasm", target_os = "unknown") },
+        macos_platform: { target_os = "macos" },
+        ios_platform: { target_os = "ios" },
+        windows_platform: { target_os = "windows" },
+        apple: { any(target_os = "ios", target_os = "macos") },
+        free_unix: { all(unix, not(apple), not(android_platform), not(target_os = "emscripten")) },
+
+        // Native displays.
+        x11_platform: { all(free_unix, feature = "sm-x11") },
+        wayland_platform: { all(free_unix) },
 
         // Features:
         // Here we collect the features that are only valid on certain platforms and
         // we add aliases that include checks for the correct platform.
         angle: { all(windows, feature = "sm-angle") },
-        angle_builtin: { all(windows, feature = "sm-angle-builtin") },
-        angle_default: { all(windows, feature = "sm-angle-default") },
-        no_wgl: { all(windows, feature = "sm-no-wgl") },
-        wayland_default: { all(linux, feature = "sm-wayland-default") },
-        x11: { all(linux, feature = "sm-x11") },
+        angle_builtin: { all(windows_platform, feature = "sm-angle-builtin") },
+        angle_default: { all(windows_platform, feature = "sm-angle-default") },
+        no_wgl: { all(windows_platform, feature = "sm-no-wgl") },
+        wayland_default: { all(wayland_platform, any(not(x11_platform), feature = "sm-wayland-default")) },
     }
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();

--- a/surfman/src/platform/generic/mod.rs
+++ b/surfman/src/platform/generic/mod.rs
@@ -2,7 +2,7 @@
 //
 //! Backends that are not specific to any operating system.
 
-#[cfg(any(android, angle, linux))]
+#[cfg(any(android_platform, angle, free_unix))]
 pub(crate) mod egl;
 
 pub mod multi;

--- a/surfman/src/platform/mod.rs
+++ b/surfman/src/platform/mod.rs
@@ -4,26 +4,26 @@
 
 pub mod generic;
 
-#[cfg(android)]
+#[cfg(android_platform)]
 pub mod android;
-#[cfg(android)]
+#[cfg(android_platform)]
 pub use android as default;
 
-#[cfg(macos)]
+#[cfg(macos_platform)]
 pub mod macos;
-#[cfg(macos)]
+#[cfg(macos_platform)]
 pub use macos::cgl as default;
-#[cfg(macos)]
+#[cfg(macos_platform)]
 pub use macos::system;
 
-#[cfg(linux)]
+#[cfg(free_unix)]
 pub mod unix;
-#[cfg(linux)]
+#[cfg(free_unix)]
 pub use unix::default;
 
-#[cfg(windows)]
+#[cfg(windows_platform)]
 pub mod windows;
 #[cfg(angle_default)]
 pub use windows::angle as default;
-#[cfg(all(windows, not(angle_default)))]
+#[cfg(all(windows_platform, not(angle_default)))]
 pub use windows::wgl as default;

--- a/surfman/src/platform/unix/mod.rs
+++ b/surfman/src/platform/unix/mod.rs
@@ -2,18 +2,17 @@
 //
 //! Backends specific to Unix-like systems, particularly Linux.
 
-// The default when x11 is enabled
-#[cfg(x11)]
+// The default when x11 is enabled, and wayland default is not explicitly selected.
+#[cfg(all(x11_platform, not(wayland_default)))]
 pub mod default;
 
-// The default when x11 is not enabled
-#[cfg(not(x11))]
+#[cfg(wayland_default)]
 pub use wayland as default;
 
-#[cfg(linux)]
+#[cfg(free_unix)]
 pub mod generic;
 
-#[cfg(linux)]
+#[cfg(wayland_platform)]
 pub mod wayland;
-#[cfg(x11)]
+#[cfg(x11_platform)]
 pub mod x11;


### PR DESCRIPTION
Fix the deny-by-default clippy lint `mismatched_target_os`. We rename the `linux` cfg option to `free_unix`, which more accurately represents how it is used. The naming follows the cfg names chosen by the `winit` crate.

The `wayland` cfg is slightly adjusted, to only be selected as the default if 1. wayland is enabled AND 2. either x11 is disabled, or the `sm-wayland-default` is selected

Example clippy error message:
```
error: operating system used in target family position
  --> surfman/src/platform/unix/mod.rs:13:1
   |
13 | #[cfg(linux)]
   | ^^^^^^-----^^
   |       |
   |       help: try: `target_os = "linux"`
   |
   = help: did you mean `unix`?
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mismatched_target_os
 ```