### PR TITLE
chore: Fix Windows workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,17 +66,17 @@ jobs:
       if: matrix.target != 'default' && startsWith(matrix.target, 'aarch64-uwp-windows-msvc') != true
       run: |
         rustup +${{steps.toolchain.outputs.name}} target add ${{ matrix.target }}
-        cargo +${{steps.toolchain.outputs.name}} build -vv ${{ matrix.features }} --target=${{ matrix.target }}
+        cargo +${{steps.toolchain.outputs.name}} build --verbose ${{ matrix.features }} --target=${{ matrix.target }}
     - name: Build
       if: matrix.target == 'default'
       run: |
-        cargo +${{steps.toolchain.outputs.name}} build -vv ${{ matrix.features }}
+        cargo +${{steps.toolchain.outputs.name}} build --verbose ${{ matrix.features }}
     - name: Build Windows
       if: startsWith(matrix.target, 'aarch64-uwp-windows-msvc')
       shell: cmd
       run: |
         rustup +${{steps.toolchain.outputs.name}} component add rust-src --target=aarch64-uwp-windows-msvc
-        cargo +${{steps.toolchain.outputs.name}} build -Z build-std -vv --target=aarch64-uwp-windows-msvc
+        cargo +${{steps.toolchain.outputs.name}} build -Z build-std --verbose --target=aarch64-uwp-windows-msvc
   Format:
     name: Run `rustfmt`
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
       shell: cmd
       run: |
         rustup +${{steps.toolchain.outputs.name}} component add rust-src --target=aarch64-uwp-windows-msvc
-        cargo +${{steps.toolchain.outputs.name}} build -Z build-std --verbose --target=aarch64-uwp-windows-msvc
+        cargo +${{steps.toolchain.outputs.name}} build -Z build-std -vv --target=aarch64-uwp-windows-msvc
   Format:
     name: Run `rustfmt`
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,9 +51,10 @@ jobs:
       run: |
         sudo apt update
         sudo apt install gcc libxxf86vm-dev libosmesa6-dev libgles2-mesa-dev -y
-    - name: Setup LLVM (Windows)
+    - name: Upgrade LLVM (Windows)
       if: runner.os == 'Windows'
       run: |
+        choco upgrade llvm -y
         echo "LLVM_PATH=C:\Program Files\LLVM\bin" >> $GITHUB_ENV
     - name: Install rust
       id: toolchain

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,11 +66,11 @@ jobs:
       if: matrix.target != 'default' && startsWith(matrix.target, 'aarch64-uwp-windows-msvc') != true
       run: |
         rustup +${{steps.toolchain.outputs.name}} target add ${{ matrix.target }}
-        cargo +${{steps.toolchain.outputs.name}} build --verbose ${{ matrix.features }} --target=${{ matrix.target }}
+        cargo +${{steps.toolchain.outputs.name}} build -vv ${{ matrix.features }} --target=${{ matrix.target }}
     - name: Build
       if: matrix.target == 'default'
       run: |
-        cargo +${{steps.toolchain.outputs.name}} build --verbose ${{ matrix.features }}
+        cargo +${{steps.toolchain.outputs.name}} build -vv ${{ matrix.features }}
     - name: Build Windows
       if: startsWith(matrix.target, 'aarch64-uwp-windows-msvc')
       shell: cmd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,10 +51,9 @@ jobs:
       run: |
         sudo apt update
         sudo apt install gcc libxxf86vm-dev libosmesa6-dev libgles2-mesa-dev -y
-    - name: Upgrade LLVM (Windows)
+    - name: Setup LLVM (Windows)
       if: runner.os == 'Windows'
       run: |
-        choco upgrade llvm --version=17.0.6 -y
         echo "LLVM_PATH=C:\Program Files\LLVM\bin" >> $GITHUB_ENV
     - name: Install rust
       id: toolchain

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,8 @@ jobs:
     - name: Upgrade LLVM (Windows)
       if: runner.os == 'Windows'
       run: |
-        choco upgrade llvm -y
+        choco uninstall llvm
+        choco upgrade llvm --version=17.0.6 -y
         echo "LLVM_PATH=C:\Program Files\LLVM\bin" >> $GITHUB_ENV
     - name: Install rust
       id: toolchain


### PR DESCRIPTION
Windows workflow currently breaks due to chocolatey return failure when updating llvm to a specific version 17.0.6 but llvm 18.1.6 is already installed. (see https://github.com/servo/surfman/actions/runs/9890578015/job/27369196314#step:4:19)

We should maybe just skip upgrading (downgrading?) it for now.