### PR TITLE
Ensure bytes per row value meets alignment requirements for macOS surfaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surfman"
 license = "MIT OR Apache-2.0 OR MPL-2.0"
 edition = "2018"
-version = "0.9.6"
+version = "0.9.7"
 authors = [
     "Patrick Walton <pcwalton@mimiga.net>",
     "Emilio Cobos Álvarez <emilio@crisal.io>",

--- a/src/platform/macos/system/surface.rs
+++ b/src/platform/macos/system/surface.rs
@@ -324,7 +324,10 @@ impl Device {
         };
 
         unsafe {
-            let bytes_per_row = IOSurfaceAlignProperty(kIOSurfaceBytesPerRow, (size.width * BYTES_PER_PIXEL) as usize) as i32;
+            let bytes_per_row = IOSurfaceAlignProperty(
+                kIOSurfaceBytesPerRow,
+                (size.width * BYTES_PER_PIXEL) as usize,
+            ) as i32;
             let properties = CFDictionary::from_CFType_pairs(&[
                 (
                     CFString::wrap_under_get_rule(kIOSurfaceWidth),


### PR DESCRIPTION
Fixes the crash observed in https://github.com/servo/servo/issues/29809. The new FFI declaration belongs in https://github.com/servo/core-foundation-rs/blob/main/io-surface/src/lib.rs#L162, but I'm putting this up now in case anybody else hit this.