### PR TITLE
Update toolchain and cfg_aliases to match servo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surfman"
 license = "MIT OR Apache-2.0 OR MPL-2.0"
 edition = "2018"
-version = "0.9.7"
+version = "0.9.8"
 authors = [
     "Patrick Walton <pcwalton@mimiga.net>",
     "Emilio Cobos Álvarez <emilio@crisal.io>",
@@ -15,7 +15,7 @@ readme = "README.md"
 
 [build-dependencies]
 gl_generator = "0.14"
-cfg_aliases = "0.1.0"
+cfg_aliases = "0.2.1"
 
 [features]
 chains = ["fnv", "sparkle"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.76"
+channel = "1.80.1"
 components = [ "rustfmt" ]
 profile = "minimal"


### PR DESCRIPTION
* Update cfg_aliases to fix the new unexpected_cfgs lint
* Update the rust_toolchain to match servo and prevent warning about -Zcheck-cfg