### PR TITLE
Bump bitflags to v2.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ sm-raw-window-handle-05 = ["dep:rwh_05"]
 sm-raw-window-handle-06 = ["dep:rwh_06"]
 
 [dependencies]
-bitflags = "1.1"
+bitflags = "2.6"
 euclid = "0.22"
 fnv = { version = "1.0", optional = true }
 lazy_static = "1"

--- a/src/context.rs
+++ b/src/context.rs
@@ -32,6 +32,7 @@ bitflags! {
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#WEBGLCONTEXTATTRIBUTES
     ///
     /// There are some extra `surfman`-specific flags as well.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     pub struct ContextAttributeFlags: u8 {
         /// Surfaces created for this context will have an alpha channel (RGBA or BGRA; i.e. 4
         /// channels, 32 bits per pixel, 8 bits per channel). If this is not present, surfaces will


### PR DESCRIPTION
This matches the version servo requires.
Changelog for 2.0: https://github.com/bitflags/bitflags/releases/tag/2.0.0

Affecting us:

- less traits are autoderived. We manually add the derives we need.

Note: surfman still pulls in an old bitflags version via `dev-dependencies` for the examples. Since that is not relevant for usage in servo, I'm ignoring that.