### PR TITLE
Use cstr literals where possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "surfman"
 license = "MIT OR Apache-2.0 OR MPL-2.0"
-edition = "2018"
+edition = "2021"
 version = "0.9.8"
 authors = [
     "Patrick Walton <pcwalton@mimiga.net>",

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -68,7 +68,7 @@ impl Shader {
             gl::ShaderSource(
                 shader,
                 1,
-                &(source.as_ptr() as *const GLchar),
+                &(source.as_ptr().cast()),
                 &(source.len() as GLint),
             );
             ck();
@@ -116,7 +116,7 @@ impl Buffer {
             gl::BufferData(
                 gl::ARRAY_BUFFER,
                 data.len() as isize,
-                data.as_ptr() as *const c_void,
+                data.as_ptr().cast(),
                 gl::STATIC_DRAW,
             );
             ck();

--- a/examples/offscreen.rs
+++ b/examples/offscreen.rs
@@ -251,10 +251,10 @@ impl TriProgram {
         let program = Program::new(vertex_shader, fragment_shader);
         unsafe {
             let position_attribute =
-                gl::GetAttribLocation(program.object, b"aPosition\0".as_ptr() as *const GLchar);
+                gl::GetAttribLocation(program.object, c"aPosition".as_ptr() as *const GLchar);
             ck();
             let color_attribute =
-                gl::GetAttribLocation(program.object, "aColor\0".as_ptr() as *const GLchar);
+                gl::GetAttribLocation(program.object, c"aColor".as_ptr() as *const GLchar);
             ck();
             TriProgram {
                 program,

--- a/examples/offscreen.rs
+++ b/examples/offscreen.rs
@@ -188,7 +188,7 @@ impl TriVertexArray {
             ck();
 
             let vertex_buffer = Buffer::from_data(slice::from_raw_parts(
-                TRI_VERTICES.as_ptr() as *const u8,
+                TRI_VERTICES.as_ptr().cast(),
                 mem::size_of::<Vertex>() * 3,
             ));
 
@@ -251,10 +251,9 @@ impl TriProgram {
         let program = Program::new(vertex_shader, fragment_shader);
         unsafe {
             let position_attribute =
-                gl::GetAttribLocation(program.object, c"aPosition".as_ptr() as *const GLchar);
+                gl::GetAttribLocation(program.object, c"aPosition".as_ptr().cast());
             ck();
-            let color_attribute =
-                gl::GetAttribLocation(program.object, c"aColor".as_ptr() as *const GLchar);
+            let color_attribute = gl::GetAttribLocation(program.object, c"aColor".as_ptr().cast());
             ck();
             TriProgram {
                 program,

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -811,26 +811,26 @@ impl BlitProgram {
         let program = Program::new(vertex_shader, fragment_shader);
         unsafe {
             let position_attribute =
-                gl::GetAttribLocation(program.object, b"aPosition\0".as_ptr() as *const GLchar);
+                gl::GetAttribLocation(program.object, c"aPosition".as_ptr() as *const GLchar);
             ck();
             let transform_uniform =
-                gl::GetUniformLocation(program.object, b"uTransform\0".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uTransform".as_ptr() as *const GLchar);
             ck();
             let translation_uniform =
-                gl::GetUniformLocation(program.object, b"uTranslation\0".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uTranslation".as_ptr() as *const GLchar);
             ck();
             let tex_transform_uniform = gl::GetUniformLocation(
                 program.object,
-                b"uTexTransform\0".as_ptr() as *const GLchar,
+                c"uTexTransform".as_ptr() as *const GLchar,
             );
             ck();
             let tex_translation_uniform = gl::GetUniformLocation(
                 program.object,
-                b"uTexTranslation\0".as_ptr() as *const GLchar,
+                c"uTexTranslation".as_ptr() as *const GLchar,
             );
             ck();
             let source_uniform =
-                gl::GetUniformLocation(program.object, b"uSource\0".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uSource".as_ptr() as *const GLchar);
             ck();
             BlitProgram {
                 program,
@@ -883,48 +883,48 @@ impl GridProgram {
         let program = Program::new(vertex_shader, fragment_shader);
         unsafe {
             let position_attribute =
-                gl::GetAttribLocation(program.object, b"aPosition\0".as_ptr() as *const GLchar);
+                gl::GetAttribLocation(program.object, c"aPosition".as_ptr() as *const GLchar);
             ck();
             let transform_uniform =
-                gl::GetUniformLocation(program.object, b"uTransform\0".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uTransform".as_ptr() as *const GLchar);
             ck();
             let translation_uniform =
-                gl::GetUniformLocation(program.object, b"uTranslation\0".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uTranslation".as_ptr() as *const GLchar);
             ck();
             let tex_transform_uniform = gl::GetUniformLocation(
                 program.object,
-                b"uTexTransform\0".as_ptr() as *const GLchar,
+                c"uTexTransform".as_ptr() as *const GLchar,
             );
             ck();
             let tex_translation_uniform = gl::GetUniformLocation(
                 program.object,
-                b"uTexTranslation\0".as_ptr() as *const GLchar,
+                c"uTexTranslation".as_ptr() as *const GLchar,
             );
             ck();
             let gridline_color_uniform = gl::GetUniformLocation(
                 program.object,
-                b"uGridlineColor\0".as_ptr() as *const GLchar,
+                c"uGridlineColor".as_ptr() as *const GLchar,
             );
             ck();
             let bg_color_uniform =
-                gl::GetUniformLocation(program.object, b"uBGColor\0".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uBGColor".as_ptr() as *const GLchar);
             ck();
             let radius_uniform =
-                gl::GetUniformLocation(program.object, b"uRadius\0".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uRadius".as_ptr() as *const GLchar);
             ck();
             let camera_position_uniform = gl::GetUniformLocation(
                 program.object,
-                b"uCameraPosition\0".as_ptr() as *const GLchar,
+                c"uCameraPosition".as_ptr() as *const GLchar,
             );
             ck();
             let light_position_uniform = gl::GetUniformLocation(
                 program.object,
-                b"uLightPosition\0".as_ptr() as *const GLchar,
+                c"uLightPosition".as_ptr() as *const GLchar,
             );
             ck();
             let sphere_position_uniform = gl::GetUniformLocation(
                 program.object,
-                b"uSpherePosition\0".as_ptr() as *const GLchar,
+                c"uSpherePosition".as_ptr() as *const GLchar,
             );
             ck();
             GridProgram {
@@ -985,54 +985,54 @@ impl CheckProgram {
         let program = Program::new(vertex_shader, fragment_shader);
         unsafe {
             let position_attribute =
-                gl::GetAttribLocation(program.object, b"aPosition\0".as_ptr() as *const GLchar);
+                gl::GetAttribLocation(program.object, c"aPosition".as_ptr() as *const GLchar);
             ck();
             let transform_uniform =
-                gl::GetUniformLocation(program.object, b"uTransform\0".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uTransform".as_ptr() as *const GLchar);
             ck();
             let translation_uniform =
-                gl::GetUniformLocation(program.object, b"uTranslation\0".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uTranslation".as_ptr() as *const GLchar);
             ck();
             let tex_transform_uniform = gl::GetUniformLocation(
                 program.object,
-                b"uTexTransform\0".as_ptr() as *const GLchar,
+                c"uTexTransform".as_ptr() as *const GLchar,
             );
             ck();
             let tex_translation_uniform = gl::GetUniformLocation(
                 program.object,
-                b"uTexTranslation\0".as_ptr() as *const GLchar,
+                c"uTexTranslation".as_ptr() as *const GLchar,
             );
             ck();
             let rotation_uniform =
-                gl::GetUniformLocation(program.object, b"uRotation\0".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uRotation".as_ptr() as *const GLchar);
             ck();
             let color_a_uniform =
-                gl::GetUniformLocation(program.object, b"uColorA\0".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uColorA".as_ptr() as *const GLchar);
             ck();
             let color_b_uniform =
-                gl::GetUniformLocation(program.object, b"uColorB\0".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uColorB".as_ptr() as *const GLchar);
             ck();
             let viewport_origin_uniform = gl::GetUniformLocation(
                 program.object,
-                b"uViewportOrigin\0".as_ptr() as *const GLchar,
+                c"uViewportOrigin".as_ptr() as *const GLchar,
             );
             ck();
             let radius_uniform =
-                gl::GetUniformLocation(program.object, b"uRadius\0".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uRadius".as_ptr() as *const GLchar);
             ck();
             let camera_position_uniform = gl::GetUniformLocation(
                 program.object,
-                b"uCameraPosition\0".as_ptr() as *const GLchar,
+                c"uCameraPosition".as_ptr() as *const GLchar,
             );
             ck();
             let light_position_uniform = gl::GetUniformLocation(
                 program.object,
-                b"uLightPosition\0".as_ptr() as *const GLchar,
+                c"uLightPosition".as_ptr() as *const GLchar,
             );
             ck();
             let sphere_position_uniform = gl::GetUniformLocation(
                 program.object,
-                b"uSpherePosition\0".as_ptr() as *const GLchar,
+                c"uSpherePosition".as_ptr() as *const GLchar,
             );
             ck();
             CheckProgram {

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -811,26 +811,21 @@ impl BlitProgram {
         let program = Program::new(vertex_shader, fragment_shader);
         unsafe {
             let position_attribute =
-                gl::GetAttribLocation(program.object, c"aPosition".as_ptr() as *const GLchar);
+                gl::GetAttribLocation(program.object, c"aPosition".as_ptr().cast());
             ck();
             let transform_uniform =
-                gl::GetUniformLocation(program.object, c"uTransform".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uTransform".as_ptr().cast());
             ck();
             let translation_uniform =
-                gl::GetUniformLocation(program.object, c"uTranslation".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uTranslation".as_ptr().cast());
             ck();
-            let tex_transform_uniform = gl::GetUniformLocation(
-                program.object,
-                c"uTexTransform".as_ptr() as *const GLchar,
-            );
+            let tex_transform_uniform =
+                gl::GetUniformLocation(program.object, c"uTexTransform".as_ptr().cast());
             ck();
-            let tex_translation_uniform = gl::GetUniformLocation(
-                program.object,
-                c"uTexTranslation".as_ptr() as *const GLchar,
-            );
+            let tex_translation_uniform =
+                gl::GetUniformLocation(program.object, c"uTexTranslation".as_ptr().cast());
             ck();
-            let source_uniform =
-                gl::GetUniformLocation(program.object, c"uSource".as_ptr() as *const GLchar);
+            let source_uniform = gl::GetUniformLocation(program.object, c"uSource".as_ptr().cast());
             ck();
             BlitProgram {
                 program,
@@ -883,49 +878,36 @@ impl GridProgram {
         let program = Program::new(vertex_shader, fragment_shader);
         unsafe {
             let position_attribute =
-                gl::GetAttribLocation(program.object, c"aPosition".as_ptr() as *const GLchar);
+                gl::GetAttribLocation(program.object, c"aPosition".as_ptr().cast());
             ck();
             let transform_uniform =
-                gl::GetUniformLocation(program.object, c"uTransform".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uTransform".as_ptr().cast());
             ck();
             let translation_uniform =
-                gl::GetUniformLocation(program.object, c"uTranslation".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uTranslation".as_ptr().cast());
             ck();
-            let tex_transform_uniform = gl::GetUniformLocation(
-                program.object,
-                c"uTexTransform".as_ptr() as *const GLchar,
-            );
+            let tex_transform_uniform =
+                gl::GetUniformLocation(program.object, c"uTexTransform".as_ptr().cast());
             ck();
-            let tex_translation_uniform = gl::GetUniformLocation(
-                program.object,
-                c"uTexTranslation".as_ptr() as *const GLchar,
-            );
+            let tex_translation_uniform =
+                gl::GetUniformLocation(program.object, c"uTexTranslation".as_ptr().cast());
             ck();
-            let gridline_color_uniform = gl::GetUniformLocation(
-                program.object,
-                c"uGridlineColor".as_ptr() as *const GLchar,
-            );
+            let gridline_color_uniform =
+                gl::GetUniformLocation(program.object, c"uGridlineColor".as_ptr().cast());
             ck();
             let bg_color_uniform =
-                gl::GetUniformLocation(program.object, c"uBGColor".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uBGColor".as_ptr().cast());
             ck();
-            let radius_uniform =
-                gl::GetUniformLocation(program.object, c"uRadius".as_ptr() as *const GLchar);
+            let radius_uniform = gl::GetUniformLocation(program.object, c"uRadius".as_ptr().cast());
             ck();
-            let camera_position_uniform = gl::GetUniformLocation(
-                program.object,
-                c"uCameraPosition".as_ptr() as *const GLchar,
-            );
+            let camera_position_uniform =
+                gl::GetUniformLocation(program.object, c"uCameraPosition".as_ptr().cast());
             ck();
-            let light_position_uniform = gl::GetUniformLocation(
-                program.object,
-                c"uLightPosition".as_ptr() as *const GLchar,
-            );
+            let light_position_uniform =
+                gl::GetUniformLocation(program.object, c"uLightPosition".as_ptr().cast());
             ck();
-            let sphere_position_uniform = gl::GetUniformLocation(
-                program.object,
-                c"uSpherePosition".as_ptr() as *const GLchar,
-            );
+            let sphere_position_uniform =
+                gl::GetUniformLocation(program.object, c"uSpherePosition".as_ptr().cast());
             ck();
             GridProgram {
                 program,
@@ -985,55 +967,42 @@ impl CheckProgram {
         let program = Program::new(vertex_shader, fragment_shader);
         unsafe {
             let position_attribute =
-                gl::GetAttribLocation(program.object, c"aPosition".as_ptr() as *const GLchar);
+                gl::GetAttribLocation(program.object, c"aPosition".as_ptr().cast());
             ck();
             let transform_uniform =
-                gl::GetUniformLocation(program.object, c"uTransform".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uTransform".as_ptr().cast());
             ck();
             let translation_uniform =
-                gl::GetUniformLocation(program.object, c"uTranslation".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uTranslation".as_ptr().cast());
             ck();
-            let tex_transform_uniform = gl::GetUniformLocation(
-                program.object,
-                c"uTexTransform".as_ptr() as *const GLchar,
-            );
+            let tex_transform_uniform =
+                gl::GetUniformLocation(program.object, c"uTexTransform".as_ptr().cast());
             ck();
-            let tex_translation_uniform = gl::GetUniformLocation(
-                program.object,
-                c"uTexTranslation".as_ptr() as *const GLchar,
-            );
+            let tex_translation_uniform =
+                gl::GetUniformLocation(program.object, c"uTexTranslation".as_ptr().cast());
             ck();
             let rotation_uniform =
-                gl::GetUniformLocation(program.object, c"uRotation".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uRotation".as_ptr().cast());
             ck();
             let color_a_uniform =
-                gl::GetUniformLocation(program.object, c"uColorA".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uColorA".as_ptr().cast());
             ck();
             let color_b_uniform =
-                gl::GetUniformLocation(program.object, c"uColorB".as_ptr() as *const GLchar);
+                gl::GetUniformLocation(program.object, c"uColorB".as_ptr().cast());
             ck();
-            let viewport_origin_uniform = gl::GetUniformLocation(
-                program.object,
-                c"uViewportOrigin".as_ptr() as *const GLchar,
-            );
+            let viewport_origin_uniform =
+                gl::GetUniformLocation(program.object, c"uViewportOrigin".as_ptr().cast());
             ck();
-            let radius_uniform =
-                gl::GetUniformLocation(program.object, c"uRadius".as_ptr() as *const GLchar);
+            let radius_uniform = gl::GetUniformLocation(program.object, c"uRadius".as_ptr().cast());
             ck();
-            let camera_position_uniform = gl::GetUniformLocation(
-                program.object,
-                c"uCameraPosition".as_ptr() as *const GLchar,
-            );
+            let camera_position_uniform =
+                gl::GetUniformLocation(program.object, c"uCameraPosition".as_ptr().cast());
             ck();
-            let light_position_uniform = gl::GetUniformLocation(
-                program.object,
-                c"uLightPosition".as_ptr() as *const GLchar,
-            );
+            let light_position_uniform =
+                gl::GetUniformLocation(program.object, c"uLightPosition".as_ptr().cast());
             ck();
-            let sphere_position_uniform = gl::GetUniformLocation(
-                program.object,
-                c"uSpherePosition".as_ptr() as *const GLchar,
-            );
+            let sphere_position_uniform =
+                gl::GetUniformLocation(program.object, c"uSpherePosition".as_ptr().cast());
             ck();
             CheckProgram {
                 program,

--- a/src/platform/generic/egl/context.rs
+++ b/src/platform/generic/egl/context.rs
@@ -16,7 +16,7 @@ use crate::{Gl, SurfaceInfo};
 
 use std::ffi::CString;
 use std::mem;
-use std::os::raw::{c_char, c_void};
+use std::os::raw::c_void;
 use std::ptr;
 use std::thread;
 
@@ -593,7 +593,7 @@ pub(crate) unsafe fn egl_config_from_id(
 pub(crate) fn get_proc_address(symbol_name: &str) -> *const c_void {
     EGL_FUNCTIONS.with(|egl| unsafe {
         let symbol_name: CString = CString::new(symbol_name).unwrap();
-        egl.GetProcAddress(symbol_name.as_ptr() as *const u8 as *const c_char) as *const c_void
+        egl.GetProcAddress(symbol_name.as_ptr()).cast()
     })
 }
 

--- a/src/platform/generic/egl/device.rs
+++ b/src/platform/generic/egl/device.rs
@@ -4,16 +4,14 @@
 
 use crate::egl::Egl;
 
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::mem;
-use std::os::raw::{c_char, c_void};
+use std::os::raw::c_void;
 
 #[cfg(not(target_os = "windows"))]
 use libc::{dlopen, dlsym, RTLD_LAZY};
 #[cfg(target_os = "windows")]
 use winapi::shared::minwindef::HMODULE;
-#[cfg(target_os = "windows")]
-use winapi::shared::ntdef::LPCSTR;
 #[cfg(target_os = "windows")]
 use winapi::um::libloaderapi;
 
@@ -25,7 +23,7 @@ thread_local! {
 lazy_static! {
     static ref EGL_LIBRARY: EGLLibraryWrapper = {
         unsafe {
-            let module = libloaderapi::LoadLibraryA(&b"libEGL.dll\0"[0] as *const u8 as LPCSTR);
+            let module = libloaderapi::LoadLibraryA(c"libEGL.dll".as_ptr());
             EGLLibraryWrapper(module)
         }
     };
@@ -34,7 +32,7 @@ lazy_static! {
 #[cfg(not(any(target_os = "windows", target_os = "macos")))]
 lazy_static! {
     static ref EGL_LIBRARY: EGLLibraryWrapper = {
-        for soname in [b"libEGL.so.1\0".as_ptr(), b"libEGL.so\0".as_ptr()] {
+        for soname in [c"libEGL.so.1".as_ptr(), c"libEGL.so".as_ptr()] {
             unsafe {
                 let handle = dlopen(soname as *const _, RTLD_LAZY);
                 if !handle.is_null() {
@@ -58,8 +56,8 @@ unsafe impl Sync for EGLLibraryWrapper {}
 fn get_proc_address(symbol_name: &str) -> *const c_void {
     unsafe {
         let symbol_name: CString = CString::new(symbol_name).unwrap();
-        let symbol_ptr = symbol_name.as_ptr() as *const u8 as LPCSTR;
-        libloaderapi::GetProcAddress(EGL_LIBRARY.0, symbol_ptr) as *const c_void
+        let symbol_ptr = symbol_name.as_ptr();
+        libloaderapi::GetProcAddress(EGL_LIBRARY.0, symbol_ptr).cast()
     }
 }
 
@@ -67,12 +65,11 @@ fn get_proc_address(symbol_name: &str) -> *const c_void {
 fn get_proc_address(symbol_name: &str) -> *const c_void {
     unsafe {
         let symbol_name: CString = CString::new(symbol_name).unwrap();
-        let symbol_ptr = symbol_name.as_ptr() as *const u8 as *const c_char;
-        dlsym(EGL_LIBRARY.0, symbol_ptr) as *const c_void
+        let symbol_ptr = symbol_name.as_ptr();
+        dlsym(EGL_LIBRARY.0, symbol_ptr).cast_const()
     }
 }
 
-pub(crate) unsafe fn lookup_egl_extension(name: &'static [u8]) -> *mut c_void {
-    EGL_FUNCTIONS
-        .with(|egl| mem::transmute(egl.GetProcAddress(&name[0] as *const u8 as *const c_char)))
+pub(crate) unsafe fn lookup_egl_extension(name: &CStr) -> *mut c_void {
+    EGL_FUNCTIONS.with(|egl| mem::transmute(egl.GetProcAddress(name.as_ptr())))
 }

--- a/src/platform/generic/egl/ffi.rs
+++ b/src/platform/generic/egl/ffi.rs
@@ -82,15 +82,15 @@ lazy_static! {
         use std::mem::transmute as cast;
         unsafe {
             EGLExtensionFunctions {
-                CreateImageKHR: cast(get(b"eglCreateImageKHR\0")),
-                DestroyImageKHR: cast(get(b"eglDestroyImageKHR\0")),
-                ImageTargetTexture2DOES: cast(get(b"glEGLImageTargetTexture2DOES\0")),
+                CreateImageKHR: cast(get(c"eglCreateImageKHR")),
+                DestroyImageKHR: cast(get(c"eglDestroyImageKHR")),
+                ImageTargetTexture2DOES: cast(get(c"glEGLImageTargetTexture2DOES")),
 
-                CreateDeviceANGLE: cast(get(b"eglCreateDeviceANGLE\0")),
-                GetNativeClientBufferANDROID: cast(get(b"eglGetNativeClientBufferANDROID\0")),
-                QueryDeviceAttribEXT: cast(get(b"eglQueryDeviceAttribEXT\0")),
-                QueryDisplayAttribEXT: cast(get(b"eglQueryDisplayAttribEXT\0")),
-                QuerySurfacePointerANGLE: cast(get(b"eglQuerySurfacePointerANGLE\0")),
+                CreateDeviceANGLE: cast(get(c"eglCreateDeviceANGLE")),
+                GetNativeClientBufferANDROID: cast(get(c"eglGetNativeClientBufferANDROID")),
+                QueryDeviceAttribEXT: cast(get(c"eglQueryDeviceAttribEXT")),
+                QueryDisplayAttribEXT: cast(get(c"eglQueryDisplayAttribEXT")),
+                QuerySurfacePointerANGLE: cast(get(c"eglQuerySurfacePointerANGLE")),
             }
         }
     };

--- a/src/platform/windows/wgl/context.rs
+++ b/src/platform/windows/wgl/context.rs
@@ -148,7 +148,7 @@ pub struct NativeContext(pub HGLRC);
 thread_local! {
     static OPENGL_LIBRARY: HMODULE = {
         unsafe {
-            libloaderapi::LoadLibraryA(&b"opengl32.dll\0"[0] as *const u8 as LPCSTR)
+            libloaderapi::LoadLibraryA(c"opengl32.dll".as_ptr())
         }
     };
 }
@@ -640,7 +640,7 @@ impl NativeContext {
 fn extension_loader_thread() -> WGLExtensionFunctions {
     unsafe {
         let instance = libloaderapi::GetModuleHandleA(ptr::null_mut());
-        let window_class_name = &b"SurfmanFalseWindow\0"[0] as *const u8 as LPCSTR;
+        let window_class_name = c"SurfmanFalseWindow".as_ptr();
         let window_class = WNDCLASSA {
             style: CS_OWNDC,
             lpfnWndProc: Some(extension_loader_window_proc),
@@ -732,9 +732,8 @@ extern "system" fn extension_loader_window_proc(
                 let create_struct = lParam as *mut CREATESTRUCTA;
                 let wgl_extension_functions =
                     (*create_struct).lpCreateParams as *mut WGLExtensionFunctions;
-                (*wgl_extension_functions).GetExtensionsStringARB = mem::transmute(
-                    wglGetProcAddress(&b"wglGetExtensionsStringARB\0"[0] as *const u8 as LPCSTR),
-                );
+                (*wgl_extension_functions).GetExtensionsStringARB =
+                    mem::transmute(wglGetProcAddress(c"wglGetExtensionsStringARB".as_ptr()));
                 let extensions = match (*wgl_extension_functions).GetExtensionsStringARB {
                     Some(wglGetExtensionsStringARB) => {
                         CStr::from_ptr(wglGetExtensionsStringARB(dc)).to_string_lossy()
@@ -748,44 +747,43 @@ extern "system" fn extension_loader_window_proc(
                         (*wgl_extension_functions).pixel_format_functions =
                             Some(WGLPixelFormatExtensionFunctions {
                                 ChoosePixelFormatARB: mem::transmute(wglGetProcAddress(
-                                    &b"wglChoosePixelFormatARB\0"[0] as *const u8 as LPCSTR,
+                                    c"wglChoosePixelFormatARB".as_ptr(),
                                 )),
                                 GetPixelFormatAttribivARB: mem::transmute(wglGetProcAddress(
-                                    &b"wglGetPixelFormatAttribivARB\0"[0] as *const u8 as LPCSTR,
+                                    c"wglGetPixelFormatAttribivARB".as_ptr(),
                                 )),
                             });
                         continue;
                     }
                     if extension == "WGL_ARB_create_context" {
-                        (*wgl_extension_functions).CreateContextAttribsARB =
-                            mem::transmute(wglGetProcAddress(
-                                &b"wglCreateContextAttribsARB\0"[0] as *const u8 as LPCSTR,
-                            ));
+                        (*wgl_extension_functions).CreateContextAttribsARB = mem::transmute(
+                            wglGetProcAddress(c"wglCreateContextAttribsARB".as_ptr()),
+                        );
                         continue;
                     }
                     if extension == "WGL_NV_DX_interop" {
                         (*wgl_extension_functions).dx_interop_functions =
                             Some(WGLDXInteropExtensionFunctions {
                                 DXCloseDeviceNV: mem::transmute(wglGetProcAddress(
-                                    &b"wglDXCloseDeviceNV\0"[0] as *const u8 as LPCSTR,
+                                    c"wglDXCloseDeviceNV".as_ptr(),
                                 )),
                                 DXLockObjectsNV: mem::transmute(wglGetProcAddress(
-                                    &b"wglDXLockObjectsNV\0"[0] as *const u8 as LPCSTR,
+                                    c"wglDXLockObjectsNV".as_ptr(),
                                 )),
                                 DXOpenDeviceNV: mem::transmute(wglGetProcAddress(
-                                    &b"wglDXOpenDeviceNV\0"[0] as *const u8 as LPCSTR,
+                                    c"wglDXOpenDeviceNV".as_ptr(),
                                 )),
                                 DXRegisterObjectNV: mem::transmute(wglGetProcAddress(
-                                    &b"wglDXRegisterObjectNV\0"[0] as *const u8 as LPCSTR,
+                                    c"wglDXRegisterObjectNV".as_ptr(),
                                 )),
                                 DXSetResourceShareHandleNV: mem::transmute(wglGetProcAddress(
-                                    &b"wglDXSetResourceShareHandleNV\0"[0] as *const u8 as LPCSTR,
+                                    c"wglDXSetResourceShareHandleNV".as_ptr(),
                                 )),
                                 DXUnlockObjectsNV: mem::transmute(wglGetProcAddress(
-                                    &b"wglDXUnlockObjectsNV\0"[0] as *const u8 as LPCSTR,
+                                    c"wglDXUnlockObjectsNV".as_ptr(),
                                 )),
                                 DXUnregisterObjectNV: mem::transmute(wglGetProcAddress(
-                                    &b"wglDXUnregisterObjectNV\0"[0] as *const u8 as LPCSTR,
+                                    c"wglDXUnregisterObjectNV".as_ptr(),
                                 )),
                             });
                         continue;
@@ -872,7 +870,7 @@ fn get_proc_address(symbol_name: &str) -> *const c_void {
     unsafe {
         // https://www.khronos.org/opengl/wiki/Load_OpenGL_Functions#Windows
         let symbol_name: CString = CString::new(symbol_name).unwrap();
-        let symbol_ptr = symbol_name.as_ptr() as *const u8 as LPCSTR;
+        let symbol_ptr = symbol_name.as_ptr();
         let addr = wglGetProcAddress(symbol_ptr) as *const c_void;
         if !addr.is_null() {
             return addr;

--- a/src/platform/windows/wgl/context.rs
+++ b/src/platform/windows/wgl/context.rs
@@ -657,9 +657,14 @@ fn extension_loader_thread() -> WGLExtensionFunctions {
         assert_ne!(window_class_atom, 0);
 
         let mut extension_functions = WGLExtensionFunctions::default();
+        // The `lpClassName` parameter of `CreateWindowExA()` takes either
+        // a pointer to a null-terminated c string, or an `ATOM` / `u16` encoded
+        // in the lower bytes of the pointer type. We do the latter by forcing an
+        // `as` cast of the ATOM to the pointer type `LPCSTR`.
+        let lpClassName = window_class_atom as LPCSTR;
         let window = winuser::CreateWindowExA(
             0,
-            window_class_atom as LPCSTR,
+            lpClassName,
             window_class_name,
             WS_OVERLAPPEDWINDOW | WS_VISIBLE,
             0,


### PR DESCRIPTION
Convert usage of byte str and normal str with a `\0` to cstr literals where possible