### PR TITLE
Replace lazy_statics with std::sync::LazyLocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ sm-raw-window-handle-06 = ["dep:rwh_06"]
 bitflags = "2.6"
 euclid = "0.22"
 fnv = { version = "1.0", optional = true }
-lazy_static = "1"
 libc = "0.2"
 log = "0.4"
 sparkle = { version = "0.1", optional = true }

--- a/src/context.rs
+++ b/src/context.rs
@@ -19,10 +19,8 @@ use std::sync::Mutex;
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct ContextID(pub u64);
 
-lazy_static! {
-    #[doc(hidden)]
-    pub static ref CREATE_CONTEXT_MUTEX: Mutex<ContextID> = Mutex::new(ContextID(0));
-}
+#[doc(hidden)]
+pub static CREATE_CONTEXT_MUTEX: Mutex<ContextID> = Mutex::new(ContextID(0));
 
 bitflags! {
     /// Various flags that control attributes of the context and/or surfaces created from that

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,6 @@
 
 #[macro_use]
 extern crate bitflags;
-#[macro_use]
-extern crate lazy_static;
 #[allow(unused_imports)]
 #[macro_use]
 extern crate log;

--- a/src/platform/generic/egl/ffi.rs
+++ b/src/platform/generic/egl/ffi.rs
@@ -8,6 +8,7 @@ use crate::egl::types::{EGLAttrib, EGLBoolean, EGLContext, EGLDeviceEXT, EGLDisp
 use crate::egl::types::{EGLenum, EGLint};
 
 use std::os::raw::c_void;
+use std::sync::LazyLock;
 
 pub enum EGLClientBufferOpaque {}
 pub type EGLClientBuffer = *mut EGLClientBufferOpaque;
@@ -76,22 +77,20 @@ pub(crate) struct EGLExtensionFunctions {
     >,
 }
 
-lazy_static! {
-    pub(crate) static ref EGL_EXTENSION_FUNCTIONS: EGLExtensionFunctions = {
-        use crate::platform::generic::egl::device::lookup_egl_extension as get;
-        use std::mem::transmute as cast;
-        unsafe {
-            EGLExtensionFunctions {
-                CreateImageKHR: cast(get(c"eglCreateImageKHR")),
-                DestroyImageKHR: cast(get(c"eglDestroyImageKHR")),
-                ImageTargetTexture2DOES: cast(get(c"glEGLImageTargetTexture2DOES")),
+pub(crate) static EGL_EXTENSION_FUNCTIONS: LazyLock<EGLExtensionFunctions> = LazyLock::new(|| {
+    use crate::platform::generic::egl::device::lookup_egl_extension as get;
+    use std::mem::transmute as cast;
+    unsafe {
+        EGLExtensionFunctions {
+            CreateImageKHR: cast(get(c"eglCreateImageKHR")),
+            DestroyImageKHR: cast(get(c"eglDestroyImageKHR")),
+            ImageTargetTexture2DOES: cast(get(c"glEGLImageTargetTexture2DOES")),
 
-                CreateDeviceANGLE: cast(get(c"eglCreateDeviceANGLE")),
-                GetNativeClientBufferANDROID: cast(get(c"eglGetNativeClientBufferANDROID")),
-                QueryDeviceAttribEXT: cast(get(c"eglQueryDeviceAttribEXT")),
-                QueryDisplayAttribEXT: cast(get(c"eglQueryDisplayAttribEXT")),
-                QuerySurfacePointerANGLE: cast(get(c"eglQuerySurfacePointerANGLE")),
-            }
+            CreateDeviceANGLE: cast(get(c"eglCreateDeviceANGLE")),
+            GetNativeClientBufferANDROID: cast(get(c"eglGetNativeClientBufferANDROID")),
+            QueryDeviceAttribEXT: cast(get(c"eglQueryDeviceAttribEXT")),
+            QueryDisplayAttribEXT: cast(get(c"eglQueryDisplayAttribEXT")),
+            QuerySurfacePointerANGLE: cast(get(c"eglQuerySurfacePointerANGLE")),
         }
-    };
-}
+    }
+});

--- a/src/platform/windows/wgl/context.rs
+++ b/src/platform/windows/wgl/context.rs
@@ -17,6 +17,7 @@ use std::ffi::{CStr, CString};
 use std::mem;
 use std::os::raw::{c_char, c_int, c_void};
 use std::ptr;
+use std::sync::LazyLock;
 use std::thread;
 use winapi::shared::minwindef::{BOOL, FALSE, FLOAT, HMODULE, LPARAM, LPVOID, LRESULT, UINT};
 use winapi::shared::minwindef::{WORD, WPARAM};
@@ -153,10 +154,8 @@ thread_local! {
     };
 }
 
-lazy_static! {
-    pub(crate) static ref WGL_EXTENSION_FUNCTIONS: WGLExtensionFunctions =
-        thread::spawn(extension_loader_thread).join().unwrap();
-}
+pub(crate) static WGL_EXTENSION_FUNCTIONS: LazyLock<WGLExtensionFunctions> =
+    LazyLock::new(|| thread::spawn(extension_loader_thread).join().unwrap());
 
 impl Device {
     /// Creates a context descriptor with the given attributes.


### PR DESCRIPTION
- Remove one instance of a useless lazystatic (`Mutex::new()` is const since Rust 1.63)
- Replace remaining instances with LazyLock and Once from the standard library as appropriate.
- Removes the lazylock dependency.