### PR TITLE
Replace sparkle with glow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ gl_generator = "0.14"
 cfg_aliases = "0.2.1"
 
 [features]
-chains = ["fnv", "sparkle"]
+chains = ["fnv", "glow"]
 default = ["sm-raw-window-handle-06"]
 sm-angle = []
 sm-angle-builtin = ["mozangle"]
@@ -37,7 +37,7 @@ euclid = "0.22"
 fnv = { version = "1.0", optional = true }
 libc = "0.2"
 log = "0.4"
-sparkle = { version = "0.1", optional = true }
+glow = { version = "0.14.2", optional = true }
 osmesa-sys = { version = "0.1", optional = true }
 rwh_05 = { package = "raw-window-handle", version = "0.5.2", features = ["std"], optional = true }
 rwh_06 = { package = "raw-window-handle", version = "0.6.2", features = ["std"], optional = true }


### PR DESCRIPTION
[`sparkle`](https://github.com/servo/sparkle) is a GL crate that is part of the Servo project, but mostly unmaintained. We would like to archive it and replace it with [`glow`](https://github.com/grovesNL/glow/tree/main), that is actively maintained and used by `wgpu` and the wider Rust community.

Part of https://github.com/servo/servo/issues/33539