### PR TITLE
fix(macOS): remove layer from superlayer when dropping

### DIFF
--- a/src/platform/macos/system/surface.rs
+++ b/src/platform/macos/system/surface.rs
@@ -487,6 +487,8 @@ impl Drop for ViewInfo {
 
             // Drop the reference that the callback was holding onto.
             let _ = mem::transmute_copy::<Arc<VblankCond>, Arc<VblankCond>>(&self.next_vblank);
+
+            self.layer.remove_from_superlayer();
         }
     }
 }


### PR DESCRIPTION
https://github.com/servo/servo/pull/34780 's macOS smoketest failed because of double free on CALayer.
I totally forgot I had to deal with various double free issues on macOS when I attempted to make window's lifetime shorter.
Winit window will also try to free it when dropping.

Could we make a new release after this?