### PR TITLE
Switch to x11-dl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ sm-angle-default = ["sm-angle"]
 sm-no-wgl = ["sm-angle-default"]
 sm-test = []
 sm-wayland-default = []
-sm-x11 = ["x11"]
+sm-x11 = ["x11-dl"]
 sm-raw-window-handle-generic = []
 sm-raw-window-handle-05 = ["dep:rwh_05"]
 sm-raw-window-handle-06 = ["dep:rwh_06"]
@@ -69,9 +69,8 @@ objc = "0.2"
 version = "0.30"
 features = ["client", "dlopen", "egl"]
 
-[target.'cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_env = "ohos"))))'.dependencies.x11]
+[target.'cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_env = "ohos"))))'.dependencies.x11-dl]
 version = "2.3.0"
-features = ["xlib"]
 optional = true
 
 # Ensure that we have a static libEGL.lib present for linking with EGL bindings.

--- a/src/platform/unix/x11/surface.rs
+++ b/src/platform/unix/x11/surface.rs
@@ -15,7 +15,7 @@ use euclid::default::Size2D;
 use glow::Texture;
 use std::marker::PhantomData;
 use std::os::raw::c_void;
-use x11::xlib::{Window, XGetGeometry};
+use x11_dl::xlib::Window;
 
 // FIXME(pcwalton): Is this right, or should it be `TEXTURE_EXTERNAL_OES`?
 const SURFACE_GL_TEXTURE_TARGET: u32 = gl::TEXTURE_2D;
@@ -113,7 +113,7 @@ impl Device {
         let display_guard = self.native_connection.lock_display();
         let (mut root_window, mut x, mut y, mut width, mut height) = (0, 0, 0, 0, 0);
         let (mut border_width, mut depth) = (0, 0);
-        XGetGeometry(
+        (self.native_connection.xlib.XGetGeometry)(
             display_guard.display(),
             x11_window,
             &mut root_window,


### PR DESCRIPTION
Everything else in servo uses x11-dl and this allows building on systems without X11 libraries installed.