### PR TITLE
Use `objc2-*` family of crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,14 +56,62 @@ serial_test = "3.1.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cgl = "0.3.2"
-cocoa = "0.25"
-core-foundation = "0.9"
-core-graphics = "0.23"
-servo-display-link = "0.2"
-io-surface = "0.15"
 mach2 = "0.4"
-metal = "0.24"
-objc = "0.2"
+objc2 = "0.6.1"
+objc2-app-kit = { version = "0.3", default-features = false, features = [
+    "std",
+    "objc2-quartz-core",
+    "objc2-core-foundation",
+    "NSResponder",
+    "NSScreen",
+    "NSView",
+    "NSGraphics",
+    "NSWindow",
+] }
+objc2-core-foundation = { version = "0.3.1", default-features = false, features = [
+    "std",
+    "CFBase",
+    "CFBundle",
+    "CFCGTypes",
+    "CFDictionary",
+    "CFNumber",
+    "CFString",
+] }
+objc2-core-video = { version = "0.3.1", default-features = false, features = [
+    "std",
+    "objc2-core-graphics",
+    "CVBase",
+    "CVDisplayLink",
+    "CVPixelBuffer",
+    "CVReturn",
+] }
+objc2-foundation = { version = "0.3.1", default-features = false, features = [
+    "std",
+    "objc2-core-foundation",
+    "NSEnumerator",
+    "NSGeometry",
+    "NSString",
+    "NSValue",
+] }
+objc2-io-surface = { version = "0.3.1", default-features = false, features = [
+    "std",
+    "libc",
+    "objc2",
+    "objc2-core-foundation",
+    "IOSurfaceRef",
+    "IOSurfaceTypes",
+] }
+objc2-metal = { version = "0.3.1", default-features = false, features = [
+    "std",
+    "MTLDevice",
+] }
+objc2-quartz-core = { version = "0.3.1", default-features = false, features = [
+    "std",
+    "objc2-core-foundation",
+    "CALayer",
+    "CATransaction",
+    "CATransform3D",
+] }
 
 [target.'cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_env = "ohos"))))'.dependencies.wayland-sys]
 version = "0.30"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,6 @@ extern crate bitflags;
 #[macro_use]
 extern crate log;
 
-#[cfg(target_os = "macos")]
-#[macro_use]
-extern crate objc;
-
 pub mod platform;
 pub use platform::default::connection::{Connection, NativeConnection};
 pub use platform::default::context::{Context, ContextDescriptor, NativeContext};

--- a/src/platform/macos/cgl/connection.rs
+++ b/src/platform/macos/cgl/connection.rs
@@ -125,15 +125,27 @@ impl Connection {
         raw_handle: rwh_05::RawWindowHandle,
         _size: Size2D<i32>,
     ) -> Result<NativeWidget, Error> {
-        use crate::platform::macos::system::surface::NSView;
-        use cocoa::base::id;
+        use objc2::{rc::Retained, MainThreadMarker};
+        use objc2_app_kit::{NSView, NSWindow};
         use rwh_05::RawWindowHandle::AppKit;
 
         match raw_handle {
-            AppKit(handle) => Ok(NativeWidget {
-                view: NSView(unsafe { msg_send![handle.ns_view as id, retain] }),
-                opaque: unsafe { msg_send![handle.ns_window as id, isOpaque] },
-            }),
+            AppKit(handle) => {
+                assert!(
+                    MainThreadMarker::new().is_some(),
+                    "NSView is only usable on the main thread"
+                );
+                // SAFETY: The pointer is valid for as long as the handle is,
+                // and we just checked that we're on the main thread.
+                let ns_view = unsafe { Retained::retain(handle.ns_view.cast::<NSView>()).unwrap() };
+                let ns_window =
+                    unsafe { Retained::retain(handle.ns_window.cast::<NSWindow>()).unwrap() };
+
+                Ok(NativeWidget {
+                    view: ns_view,
+                    opaque: unsafe { ns_window.isOpaque() },
+                })
+            }
             _ => Err(Error::IncompatibleNativeWidget),
         }
     }
@@ -146,21 +158,24 @@ impl Connection {
         handle: rwh_06::WindowHandle,
         _size: Size2D<i32>,
     ) -> Result<NativeWidget, Error> {
-        use crate::platform::macos::system::surface::NSView;
-        use cocoa::base::id;
+        use objc2::{MainThreadMarker, Message};
+        use objc2_app_kit::NSView;
         use rwh_06::RawWindowHandle::AppKit;
 
         match handle.as_raw() {
             AppKit(handle) => {
-                let ns_view = handle.ns_view.as_ptr() as id;
-                // https://developer.apple.com/documentation/appkit/nsview/1483301-window
-                let ns_window: id = unsafe { msg_send![ns_view, window] };
+                assert!(
+                    MainThreadMarker::new().is_some(),
+                    "NSView is only usable on the main thread"
+                );
+                // SAFETY: The pointer is valid for as long as the handle is,
+                // and we just checked that we're on the main thread.
+                let ns_view = unsafe { handle.ns_view.cast::<NSView>().as_ref() };
+                let ns_window = ns_view.window().expect("view must be in window");
                 Ok(NativeWidget {
-                    // Increment the nsview's reference count with retain. See:
-                    // https://developer.apple.com/documentation/objectivec/1418956-nsobject/1571946-retain
-                    view: NSView(unsafe { msg_send![ns_view, retain] }),
-                    // https://developer.apple.com/documentation/appkit/nswindow/1419086-isopaque
-                    opaque: unsafe { msg_send![ns_window, isOpaque] },
+                    // Extend the lifetime of the view.
+                    view: ns_view.retain(),
+                    opaque: unsafe { ns_window.isOpaque() },
                 })
             }
             _ => Err(Error::IncompatibleNativeWidget),

--- a/src/platform/macos/cgl/connection.rs
+++ b/src/platform/macos/cgl/connection.rs
@@ -170,7 +170,9 @@ impl Connection {
                 // SAFETY: The pointer is valid for as long as the handle is,
                 // and we just checked that we're on the main thread.
                 let ns_view = unsafe { handle.ns_view.cast::<NSView>().as_ref() };
-                let ns_window = ns_view.window().expect("view must be in window");
+                let ns_window = ns_view
+                    .window()
+                    .expect("view must be installed in a window");
                 Ok(NativeWidget {
                     // Extend the lifetime of the view.
                     view: ns_view.retain(),

--- a/src/platform/macos/cgl/connection.rs
+++ b/src/platform/macos/cgl/connection.rs
@@ -125,7 +125,7 @@ impl Connection {
         raw_handle: rwh_05::RawWindowHandle,
         _size: Size2D<i32>,
     ) -> Result<NativeWidget, Error> {
-        use objc2::{rc::Retained, MainThreadMarker};
+        use objc2::{MainThreadMarker, Message};
         use objc2_app_kit::{NSView, NSWindow};
         use rwh_05::RawWindowHandle::AppKit;
 
@@ -137,12 +137,11 @@ impl Connection {
                 );
                 // SAFETY: The pointer is valid for as long as the handle is,
                 // and we just checked that we're on the main thread.
-                let ns_view = unsafe { Retained::retain(handle.ns_view.cast::<NSView>()).unwrap() };
-                let ns_window =
-                    unsafe { Retained::retain(handle.ns_window.cast::<NSWindow>()).unwrap() };
+                let ns_view = unsafe { handle.ns_view.cast::<NSView>().as_ref().unwrap() };
+                let ns_window = unsafe { handle.ns_window.cast::<NSWindow>().as_ref().unwrap() };
 
                 Ok(NativeWidget {
-                    view: ns_view,
+                    view: ns_view.retain(),
                     opaque: unsafe { ns_window.isOpaque() },
                 })
             }

--- a/src/platform/macos/system/connection.rs
+++ b/src/platform/macos/system/connection.rs
@@ -6,21 +6,16 @@
 //! global window server connection.
 
 use super::device::{Adapter, Device, NativeDevice};
-use super::surface::{NSView, NativeWidget};
+use super::surface::NativeWidget;
 use crate::Error;
 
-use cocoa::base::id;
-use core_foundation::base::TCFType;
-use core_foundation::boolean::CFBoolean;
-use core_foundation::bundle::CFBundleGetInfoDictionary;
-use core_foundation::bundle::CFBundleGetMainBundle;
-use core_foundation::dictionary::{CFMutableDictionary, CFMutableDictionaryRef};
-use core_foundation::string::CFString;
+use objc2::rc::Retained;
+use objc2_app_kit::NSView;
+use objc2_core_foundation::{CFBoolean, CFBundle, CFMutableDictionary, CFRetained, CFString};
 
 use euclid::default::Size2D;
 
 use std::os::raw::c_void;
-use std::str::FromStr;
 
 /// A no-op connection.
 ///
@@ -40,21 +35,21 @@ impl Connection {
     pub fn new() -> Result<Connection, Error> {
         unsafe {
             // Adjust the `NSSupportsAutomaticGraphicsSwitching` key in our `Info.plist` so that we
-            // can opt into the integrated GPU if available. This is a total hack, as there's no
-            // guarantee `Info.plist` dictionaries are mutable.
-            let main_bundle = CFBundleGetMainBundle();
-            assert!(!main_bundle.is_null());
+            // can opt into the integrated GPU if available.
+            let main_bundle = CFBundle::main_bundle().unwrap();
+            let bundle_info_dictionary = main_bundle.info_dictionary().unwrap();
+
+            // This is a total hack, as there's no guarantee `Info.plist` dictionaries are mutable.
             let bundle_info_dictionary =
-                CFBundleGetInfoDictionary(main_bundle) as CFMutableDictionaryRef;
-            assert!(!bundle_info_dictionary.is_null());
-            let mut bundle_info_dictionary =
-                CFMutableDictionary::wrap_under_get_rule(bundle_info_dictionary);
-            let supports_automatic_graphics_switching_key: CFString =
-                FromStr::from_str("NSSupportsAutomaticGraphicsSwitching").unwrap();
-            let supports_automatic_graphics_switching_value: CFBoolean = CFBoolean::true_value();
-            bundle_info_dictionary.set(
-                supports_automatic_graphics_switching_key,
-                supports_automatic_graphics_switching_value,
+                CFRetained::cast_unchecked::<CFMutableDictionary>(bundle_info_dictionary);
+
+            let supports_automatic_graphics_switching_key =
+                CFString::from_str("NSSupportsAutomaticGraphicsSwitching");
+            let supports_automatic_graphics_switching_value = CFBoolean::new(true);
+            CFMutableDictionary::set_value(
+                Some(&bundle_info_dictionary),
+                &*supports_automatic_graphics_switching_key as *const _ as *const c_void,
+                &*supports_automatic_graphics_switching_value as *const _ as *const c_void,
             );
         }
 
@@ -136,8 +131,12 @@ impl Connection {
         raw: *mut c_void,
         _size: Size2D<i32>,
     ) -> NativeWidget {
+        let view_ptr: *mut NSView = raw.cast();
         NativeWidget {
-            view: NSView(raw as id),
+            // SAFETY: Validity of the NSView is upheld by caller.
+            // TODO(madsmtm): We should probably `retain` here, rather than
+            // take ownership of the pointer.
+            view: unsafe { Retained::from_raw(view_ptr).unwrap() },
             opaque: true,
         }
     }
@@ -150,13 +149,27 @@ impl Connection {
         raw_handle: rwh_05::RawWindowHandle,
         _size: Size2D<i32>,
     ) -> Result<NativeWidget, Error> {
+        use objc2::MainThreadMarker;
+        use objc2_app_kit::NSWindow;
         use rwh_05::RawWindowHandle::AppKit;
 
         match raw_handle {
-            AppKit(handle) => Ok(NativeWidget {
-                view: NSView(unsafe { msg_send![handle.ns_view as id, retain] }),
-                opaque: unsafe { msg_send![handle.ns_window as id, isOpaque] },
-            }),
+            AppKit(handle) => {
+                assert!(
+                    MainThreadMarker::new().is_some(),
+                    "NSView is only usable on the main thread"
+                );
+                // SAFETY: The pointer is valid for as long as the handle is,
+                // and we just checked that we're on the main thread.
+                let ns_view = unsafe { Retained::retain(handle.ns_view.cast::<NSView>()).unwrap() };
+                let ns_window =
+                    unsafe { Retained::retain(handle.ns_window.cast::<NSWindow>()).unwrap() };
+
+                Ok(NativeWidget {
+                    view: ns_view,
+                    opaque: unsafe { ns_window.isOpaque() },
+                })
+            }
             _ => Err(Error::IncompatibleNativeWidget),
         }
     }
@@ -169,19 +182,23 @@ impl Connection {
         handle: rwh_06::WindowHandle,
         _size: Size2D<i32>,
     ) -> Result<NativeWidget, Error> {
+        use objc2::{MainThreadMarker, Message};
         use rwh_06::RawWindowHandle::AppKit;
 
         match handle.as_raw() {
             AppKit(handle) => {
-                let ns_view = handle.ns_view.as_ptr() as id;
-                // https://developer.apple.com/documentation/appkit/nsview/1483301-window
-                let ns_window: id = unsafe { msg_send![ns_view, window] };
+                assert!(
+                    MainThreadMarker::new().is_some(),
+                    "NSView is only usable on the main thread"
+                );
+                // SAFETY: The pointer is valid for as long as the handle is,
+                // and we just checked that we're on the main thread.
+                let ns_view = unsafe { handle.ns_view.cast::<NSView>().as_ref() };
+                let ns_window = ns_view.window().expect("view must be in window");
                 Ok(NativeWidget {
-                    // Increment the nsview's reference count with retain. See:
-                    // https://developer.apple.com/documentation/objectivec/1418956-nsobject/1571946-retain
-                    view: NSView(unsafe { msg_send![ns_view, retain] }),
-                    // https://developer.apple.com/documentation/appkit/nswindow/1419086-isopaque
-                    opaque: unsafe { msg_send![ns_window, isOpaque] },
+                    // Extend the lifetime of the view.
+                    view: ns_view.retain(),
+                    opaque: unsafe { ns_window.isOpaque() },
                 })
             }
             _ => Err(Error::IncompatibleNativeWidget),

--- a/src/platform/macos/system/connection.rs
+++ b/src/platform/macos/system/connection.rs
@@ -149,7 +149,7 @@ impl Connection {
         raw_handle: rwh_05::RawWindowHandle,
         _size: Size2D<i32>,
     ) -> Result<NativeWidget, Error> {
-        use objc2::MainThreadMarker;
+        use objc2::{MainThreadMarker, Message};
         use objc2_app_kit::NSWindow;
         use rwh_05::RawWindowHandle::AppKit;
 
@@ -161,12 +161,11 @@ impl Connection {
                 );
                 // SAFETY: The pointer is valid for as long as the handle is,
                 // and we just checked that we're on the main thread.
-                let ns_view = unsafe { Retained::retain(handle.ns_view.cast::<NSView>()).unwrap() };
-                let ns_window =
-                    unsafe { Retained::retain(handle.ns_window.cast::<NSWindow>()).unwrap() };
+                let ns_view = unsafe { handle.ns_view.cast::<NSView>().as_ref().unwrap() };
+                let ns_window = unsafe { handle.ns_window.cast::<NSWindow>().as_ref().unwrap() };
 
                 Ok(NativeWidget {
-                    view: ns_view,
+                    view: ns_view.retain(),
                     opaque: unsafe { ns_window.isOpaque() },
                 })
             }

--- a/src/platform/macos/system/connection.rs
+++ b/src/platform/macos/system/connection.rs
@@ -193,7 +193,9 @@ impl Connection {
                 // SAFETY: The pointer is valid for as long as the handle is,
                 // and we just checked that we're on the main thread.
                 let ns_view = unsafe { handle.ns_view.cast::<NSView>().as_ref() };
-                let ns_window = ns_view.window().expect("view must be in window");
+                let ns_window = ns_view
+                    .window()
+                    .expect("view must be installed in a window");
                 Ok(NativeWidget {
                     // Extend the lifetime of the view.
                     view: ns_view.retain(),

--- a/src/platform/macos/system/device.rs
+++ b/src/platform/macos/system/device.rs
@@ -5,7 +5,8 @@
 use super::connection::Connection;
 use crate::Error;
 
-use metal::Device as MetalDevice;
+use objc2::{rc::Retained, runtime::ProtocolObject};
+use objc2_metal::{MTLCopyAllDevices, MTLDevice};
 use std::marker::PhantomData;
 
 /// Represents a hardware display adapter that can be used for rendering (including the CPU).
@@ -27,7 +28,7 @@ pub struct Device {
 
 /// The Metal device corresponding to this device.
 #[derive(Clone)]
-pub struct NativeDevice(pub MetalDevice);
+pub struct NativeDevice(pub Retained<ProtocolObject<dyn MTLDevice>>);
 
 impl Device {
     #[inline]
@@ -41,9 +42,9 @@ impl Device {
     /// Returns the native device corresponding to this device.
     pub fn native_device(&self) -> NativeDevice {
         NativeDevice(
-            MetalDevice::all()
+            MTLCopyAllDevices()
                 .into_iter()
-                .find(|device| device.is_low_power() == self.adapter.is_low_power)
+                .find(|device| device.isLowPower() == self.adapter.is_low_power)
                 .expect("No Metal device found!"),
         )
     }

--- a/src/platform/macos/system/ffi.rs
+++ b/src/platform/macos/system/ffi.rs
@@ -4,35 +4,8 @@
 
 #![allow(non_upper_case_globals)]
 
-use io_surface::IOSurfaceRef;
-use mach2::kern_return::kern_return_t;
-use std::os::raw::c_void;
-
-pub(crate) const kCVPixelFormatType_32BGRA: i32 = 0x42475241; // 'BGRA'
-
-pub(crate) const kCVReturnSuccess: i32 = 0;
-
 pub(crate) const kIODefaultCache: i32 = 0;
 pub(crate) const kIOWriteCombineCache: i32 = 4;
 pub(crate) const kIOMapCacheShift: i32 = 8;
 pub(crate) const kIOMapDefaultCache: i32 = kIODefaultCache << kIOMapCacheShift;
 pub(crate) const kIOMapWriteCombineCache: i32 = kIOWriteCombineCache << kIOMapCacheShift;
-
-pub(crate) type IOSurfaceLockOptions = u32;
-
-#[link(name = "IOSurface", kind = "framework")]
-extern "C" {
-    pub(crate) fn IOSurfaceGetAllocSize(buffer: IOSurfaceRef) -> usize;
-    pub(crate) fn IOSurfaceGetBaseAddress(buffer: IOSurfaceRef) -> *mut c_void;
-    pub(crate) fn IOSurfaceGetBytesPerRow(buffer: IOSurfaceRef) -> usize;
-    pub(crate) fn IOSurfaceLock(
-        buffer: IOSurfaceRef,
-        options: IOSurfaceLockOptions,
-        seed: *mut u32,
-    ) -> kern_return_t;
-    pub(crate) fn IOSurfaceUnlock(
-        buffer: IOSurfaceRef,
-        options: IOSurfaceLockOptions,
-        seed: *mut u32,
-    ) -> kern_return_t;
-}

--- a/src/platform/macos/system/surface.rs
+++ b/src/platform/macos/system/surface.rs
@@ -122,7 +122,10 @@ impl Device {
             let size = match surface_type {
                 SurfaceType::Generic { size } => size,
                 SurfaceType::Widget { ref native_widget } => {
-                    let window = native_widget.view.window().unwrap();
+                    let window = native_widget
+                        .view
+                        .window()
+                        .expect("view must be installed in a window");
                     let bounds = window.convertRectToBacking(native_widget.view.bounds());
 
                     // The surface will not appear if its width is not a multiple of 4 (i.e. stride
@@ -181,7 +184,10 @@ impl Device {
     ) -> ViewInfo {
         let front_surface = self.create_io_surface(size, surface_access);
 
-        let window = native_widget.view.window().unwrap();
+        let window = native_widget
+            .view
+            .window()
+            .expect("view must be installed in a window");
         let device_description = window.screen().unwrap().deviceDescription();
         let display_id = device_description
             .objectForKey(ns_string!("NSScreenNumber"))
@@ -214,7 +220,10 @@ impl Device {
         native_widget.view.setWantsLayer(true);
 
         // Compute logical size.
-        let window = native_widget.view.window().unwrap();
+        let window = native_widget
+            .view
+            .window()
+            .expect("view must be installed in a window");
         let logical_rect = window.convertRectFromBacking(NSRect {
             origin: NSPoint { x: 0.0, y: 0.0 },
             size: NSSize {
@@ -288,7 +297,10 @@ impl Device {
         CATransaction::setDisableActions(true);
 
         // Compute logical size.
-        let window = view_info.view.window().unwrap();
+        let window = view_info
+            .view
+            .window()
+            .expect("view must be installed in a window");
         let logical_rect = unsafe {
             window.convertRectFromBacking(NSRect {
                 origin: NSPoint { x: 0.0, y: 0.0 },


### PR DESCRIPTION
The `objc2-*` family of crates provide many benefits over the `core-foundation-rs` crates, most notably here is that the bindings are auto-generated and thus much more complete (meaning that we can avoid the error-prone `msg_send!` in almost all cases).

See https://github.com/servo/core-foundation-rs/issues/729 for additional motivation.