### PR TITLE
CI: Add timeout to test step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,7 @@ jobs:
           WAYLAND_DISPLAY=wl-test-env xvfb-run cargo test --features "${{ matrix.features }}" --target ${{ matrix.platform.target }} -- --test-threads 1
       - name: Test
         if: ${{ matrix.platform.test && !startsWith(matrix.platform.os, 'ubuntu') }}
+        timeout-minutes: 30 # https://github.com/servo/surfman/issues/329
         run: |
           cargo test --features "${{ matrix.features }}" --target ${{ matrix.platform.target }}
 


### PR DESCRIPTION
As reported in #329 we sometimes hit a freeze which causes [a job to hit 6h limit of GH runners](https://github.com/servo/surfman/actions/runs/15931224665/job/44940648538). Instead of hogging runner for 6h, let's lower the limit to 30min, as the job is dead anyway.