### PR TITLE
Update Rust toolchain to 1.89.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install rust
         id: toolchain
-        uses: dtolnay/rust-toolchain@1.81.0
+        uses: dtolnay/rust-toolchain@1.89.0
         with:
           targets: x86_64-linux-android
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
           version: "20"
       - name: Install rust
         id: toolchain
-        uses: dtolnay/rust-toolchain@1.81.0
+        uses: dtolnay/rust-toolchain@1.89.0
         with:
           targets: ${{ matrix.platform.target }}
       - name: Build

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.89.0"
 components = ["rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
This matches the current toolchain used by Servo. The indexmap dependency currently requires >=1.82.