### PR TITLE
Do not require mutability when operating on `Device`

### DIFF
--- a/examples/offscreen.rs
+++ b/examples/offscreen.rs
@@ -98,7 +98,7 @@ fn main() {
     let output_path = Path::new(matches.value_of("OUTPUT").unwrap()).to_owned();
     let output_file = File::create(output_path).unwrap();
 
-    let mut device = connection.create_device(&adapter).unwrap();
+    let device = connection.create_device(&adapter).unwrap();
 
     let context_attributes = ContextAttributes {
         version: GLVersion::new(3, 3),

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -139,7 +139,7 @@ fn main() {
     let window_size = Size2D::new(window_size.width as i32, window_size.height as i32);
     let native_widget = make_native_widget(&window, &connection, window_size);
     let adapter = connection.create_low_power_adapter().unwrap();
-    let mut device = connection.create_device(&adapter).unwrap();
+    let device = connection.create_device(&adapter).unwrap();
 
     let context_attributes = ContextAttributes {
         version: GLVersion::new(3, 0),
@@ -449,7 +449,7 @@ fn worker_thread(
     // Open the device, create a context, and make it current.
     let size = Size2D::new(SUBSCREEN_WIDTH, SUBSCREEN_HEIGHT);
     let surface_type = SurfaceType::Generic { size };
-    let mut device = connection.create_device(&adapter).unwrap();
+    let device = connection.create_device(&adapter).unwrap();
     let mut context = device.create_context(&context_descriptor, None).unwrap();
     let surface = device
         .create_surface(&context, SurfaceAccess::GPUOnly, surface_type)

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -144,7 +144,7 @@ impl<Device: DeviceAPI> SwapChainData<Device> {
     // Returns an error if `context` is not the producer context for this swap chain.
     fn swap_buffers(
         &mut self,
-        device: &mut Device,
+        device: &Device,
         context: &mut Device::Context,
         preserve_buffer: PreserveBuffer<'_>,
     ) -> Result<(), Error> {
@@ -235,7 +235,7 @@ impl<Device: DeviceAPI> SwapChainData<Device> {
     // Returns an error if this swap chain is attached, or the other swap chain is detached.
     fn take_attachment_from(
         &mut self,
-        device: &mut Device,
+        device: &Device,
         context: &mut Device::Context,
         other: &mut SwapChainData<Device>,
     ) -> Result<(), Error> {
@@ -260,7 +260,7 @@ impl<Device: DeviceAPI> SwapChainData<Device> {
     // Returns an error if `size` is smaller than (1, 1).
     fn resize(
         &mut self,
-        device: &mut Device,
+        device: &Device,
         context: &mut Device::Context,
         size: Size2D<i32>,
     ) -> Result<(), Error> {
@@ -340,7 +340,7 @@ impl<Device: DeviceAPI> SwapChainData<Device> {
     // Returns an error if `context` is not the producer context for this swap chain.
     fn clear_surface(
         &mut self,
-        device: &mut Device,
+        device: &Device,
         context: &mut Device::Context,
         gl: &Gl,
         color: [f32; 4],
@@ -454,7 +454,7 @@ impl<Device: DeviceAPI> SwapChainData<Device> {
     // Destroy the swap chain.
     // Called by the producer.
     // Returns an error if `context` is not the producer context for this swap chain.
-    fn destroy(&mut self, device: &mut Device, context: &mut Device::Context) -> Result<(), Error> {
+    fn destroy(&mut self, device: &Device, context: &mut Device::Context) -> Result<(), Error> {
         self.validate_context(device, context)?;
         let surfaces = self
             .pending_surface
@@ -490,7 +490,7 @@ impl<Device: DeviceAPI> SwapChain<Device> {
     /// Returns an error if `context` is not the producer context for this swap chain.
     pub fn swap_buffers(
         &self,
-        device: &mut Device,
+        device: &Device,
         context: &mut Device::Context,
         preserve_buffer: PreserveBuffer<'_>,
     ) -> Result<(), Error> {
@@ -503,7 +503,7 @@ impl<Device: DeviceAPI> SwapChain<Device> {
     /// Returns an error if this swap chain is attached, or the other swap chain is detached.
     pub fn take_attachment_from(
         &self,
-        device: &mut Device,
+        device: &Device,
         context: &mut Device::Context,
         other: &SwapChain<Device>,
     ) -> Result<(), Error> {
@@ -518,7 +518,7 @@ impl<Device: DeviceAPI> SwapChain<Device> {
     /// Returns an error if `context` is not the producer context for this swap chain.
     pub fn resize(
         &self,
-        device: &mut Device,
+        device: &Device,
         context: &mut Device::Context,
         size: Size2D<i32>,
     ) -> Result<(), Error> {
@@ -565,7 +565,7 @@ impl<Device: DeviceAPI> SwapChain<Device> {
     /// Returns an error if `context` is not the producer context for this swap chain.
     pub fn clear_surface(
         &self,
-        device: &mut Device,
+        device: &Device,
         context: &mut Device::Context,
         gl: &Gl,
         color: [f32; 4],
@@ -581,13 +581,13 @@ impl<Device: DeviceAPI> SwapChain<Device> {
     /// Destroy the swap chain.
     /// Called by the producer.
     /// Returns an error if `context` is not the producer context for this swap chain.
-    pub fn destroy(&self, device: &mut Device, context: &mut Device::Context) -> Result<(), Error> {
+    pub fn destroy(&self, device: &Device, context: &mut Device::Context) -> Result<(), Error> {
         self.lock().destroy(device, context)
     }
 
     /// Create a new attached swap chain
     pub fn create_attached(
-        device: &mut Device,
+        device: &Device,
         context: &mut Device::Context,
         surface_access: SurfaceAccess,
     ) -> Result<SwapChain<Device>, Error> {
@@ -604,7 +604,7 @@ impl<Device: DeviceAPI> SwapChain<Device> {
 
     /// Create a new detached swap chain
     pub fn create_detached(
-        device: &mut Device,
+        device: &Device,
         context: &mut Device::Context,
         surface_access: SurfaceAccess,
         size: Size2D<i32>,
@@ -695,7 +695,7 @@ where
     pub fn create_attached_swap_chain(
         &self,
         id: SwapChainID,
-        device: &mut Device,
+        device: &Device,
         context: &mut Device::Context,
         surface_access: SurfaceAccess,
     ) -> Result<(), Error> {
@@ -718,7 +718,7 @@ where
         &self,
         id: SwapChainID,
         size: Size2D<i32>,
-        device: &mut Device,
+        device: &Device,
         context: &mut Device::Context,
         surface_access: SurfaceAccess,
     ) -> Result<(), Error> {
@@ -744,7 +744,7 @@ where
     pub fn destroy(
         &self,
         id: SwapChainID,
-        device: &mut Device,
+        device: &Device,
         context: &mut Device::Context,
     ) -> Result<(), Error> {
         if let Some(swap_chain) = self.table_mut().remove(&id) {
@@ -758,11 +758,7 @@ where
 
     /// Destroy all the swap chains for a particular producer context.
     /// Called by the producer.
-    pub fn destroy_all(
-        &self,
-        device: &mut Device,
-        context: &mut Device::Context,
-    ) -> Result<(), Error> {
+    pub fn destroy_all(&self, device: &Device, context: &mut Device::Context) -> Result<(), Error> {
         if let Some(mut ids) = self.ids().remove(&device.context_id(context)) {
             for id in ids.drain() {
                 if let Some(swap_chain) = self.table_mut().remove(&id) {
@@ -777,7 +773,7 @@ where
     /// Called by the producer.
     pub fn iter(
         &self,
-        device: &mut Device,
+        device: &Device,
         context: &mut Device::Context,
     ) -> impl Iterator<Item = (SwapChainID, SwapChain<Device>)> {
         self.ids()

--- a/src/device.rs
+++ b/src/device.rs
@@ -58,7 +58,7 @@ where
     /// The context initially has no surface attached. Until a surface is bound to it, rendering
     /// commands will fail or have no effect.
     fn create_context(
-        &mut self,
+        &self,
         descriptor: &Self::ContextDescriptor,
         share_with: Option<&Self::Context>,
     ) -> Result<Self::Context, Error>;
@@ -151,7 +151,7 @@ where
     /// Only the given context may ever render to the surface, but generic surfaces can be wrapped
     /// up in a `SurfaceTexture` for reading by other contexts.
     fn create_surface(
-        &mut self,
+        &self,
         context: &Self::Context,
         surface_access: SurfaceAccess,
         surface_type: SurfaceType<<Self::Connection as ConnectionInterface>::NativeWidget>,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -191,7 +191,7 @@ macro_rules! implement_interfaces {
 
                 #[inline]
                 fn create_context(
-                    &mut self,
+                    &self,
                     descriptor: &Self::ContextDescriptor,
                     share_with: Option<&Self::Context>,
                 ) -> Result<Self::Context, Error> {
@@ -282,7 +282,7 @@ macro_rules! implement_interfaces {
 
                 #[inline]
                 fn create_surface(
-                    &mut self,
+                    &self,
                     context: &Self::Context,
                     surface_access: SurfaceAccess,
                     surface_type: SurfaceType<NativeWidget>,

--- a/src/platform/egl/context.rs
+++ b/src/platform/egl/context.rs
@@ -86,7 +86,7 @@ impl Device {
     /// The context initially has no surface attached. Until a surface is bound to it, rendering
     /// commands will fail or have no effect.
     pub fn create_context(
-        &mut self,
+        &self,
         descriptor: &ContextDescriptor,
         share_with: Option<&Context>,
     ) -> Result<Context, Error> {

--- a/src/platform/egl/surface/android_surface.rs
+++ b/src/platform/egl/surface/android_surface.rs
@@ -62,7 +62,7 @@ impl Device {
     /// Only the given context may ever render to the surface, but generic surfaces can be wrapped
     /// up in a `SurfaceTexture` for reading by other contexts.
     pub fn create_surface(
-        &mut self,
+        &self,
         context: &Context,
         _: SurfaceAccess,
         surface_type: SurfaceType<NativeWidget>,
@@ -76,7 +76,7 @@ impl Device {
     }
 
     fn create_generic_surface(
-        &mut self,
+        &self,
         context: &Context,
         size: &Size2D<i32>,
     ) -> Result<Surface, Error> {
@@ -143,7 +143,7 @@ impl Device {
     }
 
     unsafe fn create_window_surface(
-        &mut self,
+        &self,
         context: &Context,
         native_window: *mut ANativeWindow,
     ) -> Result<Surface, Error> {

--- a/src/platform/egl/surface/ohos_surface.rs
+++ b/src/platform/egl/surface/ohos_surface.rs
@@ -59,7 +59,7 @@ impl Device {
     /// Only the given context may ever render to the surface, but generic surfaces can be wrapped
     /// up in a `SurfaceTexture` for reading by other contexts.
     pub fn create_surface(
-        &mut self,
+        &self,
         context: &Context,
         _: SurfaceAccess,
         surface_type: SurfaceType<NativeWidget>,
@@ -74,7 +74,7 @@ impl Device {
     }
 
     fn create_generic_surface(
-        &mut self,
+        &self,
         context: &Context,
         size: &Size2D<i32>,
     ) -> Result<Surface, Error> {
@@ -135,7 +135,7 @@ impl Device {
     }
 
     unsafe fn create_window_surface(
-        &mut self,
+        &self,
         context: &Context,
         native_widget: NativeWidget,
     ) -> Result<Surface, Error> {

--- a/src/platform/generic/multi/context.rs
+++ b/src/platform/generic/multi/context.rs
@@ -90,12 +90,12 @@ where
     /// The context initially has no surface attached. Until a surface is bound to it, rendering
     /// commands will fail or have no effect.
     pub fn create_context(
-        &mut self,
+        &self,
         descriptor: &ContextDescriptor<Def, Alt>,
         share_with: Option<&Context<Def, Alt>>,
     ) -> Result<Context<Def, Alt>, Error> {
-        match (&mut *self, descriptor) {
-            (&mut Device::Default(ref mut device), ContextDescriptor::Default(descriptor)) => {
+        match (self, descriptor) {
+            (&Device::Default(ref device), ContextDescriptor::Default(descriptor)) => {
                 let shared = match share_with {
                     Some(Context::Default(other)) => Some(other),
                     Some(_) => {
@@ -107,7 +107,7 @@ where
                     .create_context(descriptor, shared)
                     .map(Context::Default)
             }
-            (&mut Device::Alternate(ref mut device), ContextDescriptor::Alternate(descriptor)) => {
+            (&Device::Alternate(ref device), ContextDescriptor::Alternate(descriptor)) => {
                 let shared = match share_with {
                     Some(Context::Alternate(other)) => Some(other),
                     Some(_) => {

--- a/src/platform/generic/multi/device.rs
+++ b/src/platform/generic/multi/device.rs
@@ -157,7 +157,7 @@ where
 
     #[inline]
     fn create_context(
-        &mut self,
+        &self,
         descriptor: &ContextDescriptor<Def, Alt>,
         share_with: Option<&Context<Def, Alt>>,
     ) -> Result<Context<Def, Alt>, Error> {
@@ -244,7 +244,7 @@ where
 
     #[inline]
     fn create_surface(
-        &mut self,
+        &self,
         context: &Context<Def, Alt>,
         surface_access: SurfaceAccess,
         surface_type: SurfaceType<NativeWidget<Def, Alt>>,

--- a/src/platform/generic/multi/surface.rs
+++ b/src/platform/generic/multi/surface.rs
@@ -101,13 +101,13 @@ where
     /// Only the given context may ever render to the surface, but generic surfaces can be wrapped
     /// up in a `SurfaceTexture` for reading by other contexts.
     pub fn create_surface(
-        &mut self,
+        &self,
         context: &Context<Def, Alt>,
         surface_access: SurfaceAccess,
         surface_type: SurfaceType<NativeWidget<Def, Alt>>,
     ) -> Result<Surface<Def, Alt>, Error> {
-        match (&mut *self, context) {
-            (&mut Device::Default(ref mut device), Context::Default(context)) => {
+        match (self, context) {
+            (&Device::Default(ref device), Context::Default(context)) => {
                 let surface_type = match surface_type {
                     SurfaceType::Generic { size } => SurfaceType::Generic { size },
                     SurfaceType::Widget {
@@ -121,7 +121,7 @@ where
                     .create_surface(context, surface_access, surface_type)
                     .map(Surface::Default)
             }
-            (&mut Device::Alternate(ref mut device), Context::Alternate(context)) => {
+            (&Device::Alternate(ref device), Context::Alternate(context)) => {
                 let surface_type = match surface_type {
                     SurfaceType::Generic { size } => SurfaceType::Generic { size },
                     SurfaceType::Widget {

--- a/src/platform/macos/cgl/context.rs
+++ b/src/platform/macos/cgl/context.rs
@@ -211,7 +211,7 @@ impl Device {
     /// The context initially has no surface attached. Until a surface is bound to it, rendering
     /// commands will fail or have no effect.
     pub fn create_context(
-        &mut self,
+        &self,
         descriptor: &ContextDescriptor,
         share_with: Option<&Context>,
     ) -> Result<Context, Error> {

--- a/src/platform/macos/cgl/surface.rs
+++ b/src/platform/macos/cgl/surface.rs
@@ -115,7 +115,7 @@ impl Device {
     /// Only the given context may ever render to the surface, but generic surfaces can be wrapped
     /// up in a `SurfaceTexture` for reading by other contexts.
     pub fn create_surface(
-        &mut self,
+        &self,
         context: &Context,
         access: SurfaceAccess,
         surface_type: SurfaceType<NativeWidget>,

--- a/src/platform/macos/system/surface.rs
+++ b/src/platform/macos/system/surface.rs
@@ -114,7 +114,7 @@ pub struct SurfaceDataGuard<'a> {
 impl Device {
     /// Creates either a generic or a widget surface, depending on the supplied surface type.
     pub fn create_surface(
-        &mut self,
+        &self,
         access: SurfaceAccess,
         surface_type: SurfaceType<NativeWidget>,
     ) -> Result<Surface, Error> {
@@ -177,7 +177,7 @@ impl Device {
 
     #[allow(deprecated)]
     unsafe fn create_view_info(
-        &mut self,
+        &self,
         size: &Size2D<i32>,
         surface_access: SurfaceAccess,
         native_widget: &NativeWidget,

--- a/src/platform/unix/generic/context.rs
+++ b/src/platform/unix/generic/context.rs
@@ -66,7 +66,7 @@ impl Device {
     /// commands will fail or have no effect.
     #[inline]
     pub fn create_context(
-        &mut self,
+        &self,
         descriptor: &ContextDescriptor,
         share_with: Option<&Context>,
     ) -> Result<Context, Error> {

--- a/src/platform/unix/generic/surface.rs
+++ b/src/platform/unix/generic/surface.rs
@@ -58,7 +58,7 @@ impl Device {
     /// Only the given context may ever render to the surface, but generic surfaces can be wrapped
     /// up in a `SurfaceTexture` for reading by other contexts.
     pub fn create_surface(
-        &mut self,
+        &self,
         context: &Context,
         _: SurfaceAccess,
         surface_type: SurfaceType<NativeWidget>,
@@ -70,7 +70,7 @@ impl Device {
     }
 
     fn create_generic_surface(
-        &mut self,
+        &self,
         context: &Context,
         size: &Size2D<i32>,
     ) -> Result<Surface, Error> {

--- a/src/platform/unix/wayland/context.rs
+++ b/src/platform/unix/wayland/context.rs
@@ -64,7 +64,7 @@ impl Device {
     /// commands will fail or have no effect.
     #[inline]
     pub fn create_context(
-        &mut self,
+        &self,
         descriptor: &ContextDescriptor,
         share_with: Option<&Context>,
     ) -> Result<Context, Error> {

--- a/src/platform/unix/wayland/surface.rs
+++ b/src/platform/unix/wayland/surface.rs
@@ -65,7 +65,7 @@ impl Device {
     /// Only the given context may ever render to the surface, but generic surfaces can be wrapped
     /// up in a `SurfaceTexture` for reading by other contexts.
     pub fn create_surface(
-        &mut self,
+        &self,
         context: &Context,
         _: SurfaceAccess,
         surface_type: SurfaceType<NativeWidget>,
@@ -83,7 +83,7 @@ impl Device {
     }
 
     fn create_generic_surface(
-        &mut self,
+        &self,
         context: &Context,
         size: &Size2D<i32>,
     ) -> Result<Surface, Error> {
@@ -102,7 +102,7 @@ impl Device {
     }
 
     unsafe fn create_window_surface(
-        &mut self,
+        &self,
         context: &Context,
         wayland_surface: *mut wl_proxy,
         size: &Size2D<i32>,

--- a/src/platform/unix/x11/context.rs
+++ b/src/platform/unix/x11/context.rs
@@ -64,7 +64,7 @@ impl Device {
     /// commands will fail or have no effect.
     #[inline]
     pub fn create_context(
-        &mut self,
+        &self,
         descriptor: &ContextDescriptor,
         share_with: Option<&Context>,
     ) -> Result<Context, Error> {

--- a/src/platform/unix/x11/surface.rs
+++ b/src/platform/unix/x11/surface.rs
@@ -65,7 +65,7 @@ impl Device {
     /// Only the given context may ever render to the surface, but generic surfaces can be wrapped
     /// up in a `SurfaceTexture` for reading by other contexts.
     pub fn create_surface(
-        &mut self,
+        &self,
         context: &Context,
         _: SurfaceAccess,
         surface_type: SurfaceType<NativeWidget>,
@@ -79,7 +79,7 @@ impl Device {
     }
 
     fn create_generic_surface(
-        &mut self,
+        &self,
         context: &Context,
         size: &Size2D<i32>,
     ) -> Result<Surface, Error> {
@@ -98,7 +98,7 @@ impl Device {
     }
 
     unsafe fn create_window_surface(
-        &mut self,
+        &self,
         context: &Context,
         mut x11_window: Window,
     ) -> Result<Surface, Error> {

--- a/src/platform/windows/angle/context.rs
+++ b/src/platform/windows/angle/context.rs
@@ -86,7 +86,7 @@ impl Device {
     /// The context initially has no surface attached. Until a surface is bound to it, rendering
     /// commands will fail or have no effect.
     pub fn create_context(
-        &mut self,
+        &self,
         descriptor: &ContextDescriptor,
         share_with: Option<&Context>,
     ) -> Result<Context, Error> {

--- a/src/platform/windows/angle/surface.rs
+++ b/src/platform/windows/angle/surface.rs
@@ -128,7 +128,7 @@ impl Device {
     /// Only the given context may ever render to the surface, but generic surfaces can be wrapped
     /// up in a `SurfaceTexture` for reading by other contexts.
     pub fn create_surface(
-        &mut self,
+        &self,
         context: &Context,
         _: SurfaceAccess,
         surface_type: SurfaceType<NativeWidget>,
@@ -143,7 +143,7 @@ impl Device {
 
     #[allow(non_snake_case)]
     fn create_pbuffer_surface(
-        &mut self,
+        &self,
         context: &Context,
         size: &Size2D<i32>,
         texture: Option<ComPtr<d3d11::ID3D11Texture2D>>,
@@ -238,7 +238,7 @@ impl Device {
     /// Given a D3D11 texture, create a surface that wraps that texture. This method is unsafe
     /// in that the resulting surface is only valid on the current thread.
     pub unsafe fn create_surface_from_texture(
-        &mut self,
+        &self,
         context: &Context,
         size: &Size2D<i32>,
         texture: ComPtr<d3d11::ID3D11Texture2D>,
@@ -247,7 +247,7 @@ impl Device {
     }
 
     fn create_window_surface(
-        &mut self,
+        &self,
         context: &Context,
         native_widget: &NativeWidget,
     ) -> Result<Surface, Error> {
@@ -425,7 +425,7 @@ impl Device {
     /// in that the resulting surface is only valid on the current thread, for the lifetime of `texture`.
     /// It is the caller's responsibility to ensure that `texture` is not freed while the `SurfaceTexture` is live.
     pub unsafe fn create_surface_texture_from_texture(
-        &mut self,
+        &self,
         context: &mut Context,
         size: &Size2D<i32>,
         texture: ComPtr<d3d11::ID3D11Texture2D>,

--- a/src/platform/windows/wgl/context.rs
+++ b/src/platform/windows/wgl/context.rs
@@ -246,7 +246,7 @@ impl Device {
     /// commands will fail or have no effect.
     #[allow(non_snake_case)]
     pub fn create_context(
-        &mut self,
+        &self,
         descriptor: &ContextDescriptor,
         share_with: Option<&Context>,
     ) -> Result<Context, Error> {

--- a/src/platform/windows/wgl/surface.rs
+++ b/src/platform/windows/wgl/surface.rs
@@ -133,7 +133,7 @@ impl Device {
     /// Only the given context may ever render to the surface, but generic surfaces can be wrapped
     /// up in a `SurfaceTexture` for reading by other contexts.
     pub fn create_surface(
-        &mut self,
+        &self,
         context: &Context,
         _: SurfaceAccess,
         surface_type: SurfaceType<NativeWidget>,
@@ -147,7 +147,7 @@ impl Device {
     }
 
     fn create_generic_surface(
-        &mut self,
+        &self,
         context: &Context,
         size: &Size2D<i32>,
     ) -> Result<Surface, Error> {
@@ -271,7 +271,7 @@ impl Device {
     }
 
     fn create_widget_surface(
-        &mut self,
+        &self,
         context: &Context,
         native_widget: NativeWidget,
     ) -> Result<Surface, Error> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -90,7 +90,7 @@ pub fn test_context_creation() {
     let adapter = connection
         .create_low_power_adapter()
         .expect("Failed to create adapter!");
-    let mut device = match connection.create_device(&adapter) {
+    let device = match connection.create_device(&adapter) {
         Ok(device) => device,
         Err(Error::RequiredExtensionUnavailable) => {
             // Can't run these tests on this hardware.
@@ -246,7 +246,7 @@ pub fn test_context_sharing() {
     let adapter = connection
         .create_low_power_adapter()
         .expect("Failed to create adapter!");
-    let mut device = match connection.create_device(&adapter) {
+    let device = match connection.create_device(&adapter) {
         Ok(device) => device,
         Err(Error::RequiredExtensionUnavailable) => {
             // Can't run these tests on this hardware.
@@ -287,7 +287,7 @@ pub fn test_generic_surface_creation() {
     let adapter = connection
         .create_low_power_adapter()
         .expect("Failed to create adapter!");
-    let mut device = match connection.create_device(&adapter) {
+    let device = match connection.create_device(&adapter) {
         Ok(device) => device,
         Err(Error::RequiredExtensionUnavailable) => {
             // Can't run these tests on this hardware.
@@ -711,7 +711,7 @@ pub fn test_surface_texture_right_side_up() {
         clear(&env.gl, &[255, 0, 0, 255]);
         assert_eq!(get_pixel_from_bottom_row(&env.gl), [255, 0, 0, 255]);
 
-        let mut subframebuffer_object = make_fbo(
+        let subframebuffer_object = make_fbo(
             &env.gl,
             env.device.surface_gl_texture_target(),
             env.device.surface_texture_object(&subsurface_texture),


### PR DESCRIPTION
No backend needs this to be mutable, so we can remove the mutability
qualifier from all implementations.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
