### PR TITLE
Fix warnings and upgrade `objc2-*` crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ serial_test = "3.1.0"
 [target.'cfg(target_os = "macos")'.dependencies]
 cgl = "0.3.2"
 objc2 = "0.6.1"
-objc2-app-kit = { version = "0.3", default-features = false, features = [
+objc2-app-kit = { version = "0.3.2", default-features = false, features = [
     "std",
     "objc2-quartz-core",
     "objc2-core-foundation",
@@ -67,7 +67,7 @@ objc2-app-kit = { version = "0.3", default-features = false, features = [
     "NSGraphics",
     "NSWindow",
 ] }
-objc2-core-foundation = { version = "0.3.1", default-features = false, features = [
+objc2-core-foundation = { version = "0.3.2", default-features = false, features = [
     "std",
     "CFBase",
     "CFBundle",
@@ -76,7 +76,7 @@ objc2-core-foundation = { version = "0.3.1", default-features = false, features 
     "CFNumber",
     "CFString",
 ] }
-objc2-core-video = { version = "0.3.1", default-features = false, features = [
+objc2-core-video = { version = "0.3.2", default-features = false, features = [
     "std",
     "objc2-core-graphics",
     "CVBase",
@@ -84,7 +84,7 @@ objc2-core-video = { version = "0.3.1", default-features = false, features = [
     "CVPixelBuffer",
     "CVReturn",
 ] }
-objc2-foundation = { version = "0.3.1", default-features = false, features = [
+objc2-foundation = { version = "0.3.2", default-features = false, features = [
     "std",
     "objc2-core-foundation",
     "NSEnumerator",
@@ -92,7 +92,7 @@ objc2-foundation = { version = "0.3.1", default-features = false, features = [
     "NSString",
     "NSValue",
 ] }
-objc2-io-surface = { version = "0.3.1", default-features = false, features = [
+objc2-io-surface = { version = "0.3.2", default-features = false, features = [
     "std",
     "libc",
     "objc2",
@@ -100,11 +100,11 @@ objc2-io-surface = { version = "0.3.1", default-features = false, features = [
     "IOSurfaceRef",
     "IOSurfaceTypes",
 ] }
-objc2-metal = { version = "0.3.1", default-features = false, features = [
+objc2-metal = { version = "0.3.2", default-features = false, features = [
     "std",
     "MTLDevice",
 ] }
-objc2-quartz-core = { version = "0.3.1", default-features = false, features = [
+objc2-quartz-core = { version = "0.3.2", default-features = false, features = [
     "std",
     "objc2-core-foundation",
     "CALayer",

--- a/src/platform/macos/cgl/connection.rs
+++ b/src/platform/macos/cgl/connection.rs
@@ -142,7 +142,7 @@ impl Connection {
 
                 Ok(NativeWidget {
                     view: ns_view.retain(),
-                    opaque: unsafe { ns_window.isOpaque() },
+                    opaque: ns_window.isOpaque(),
                 })
             }
             _ => Err(Error::IncompatibleNativeWidget),
@@ -176,7 +176,7 @@ impl Connection {
                 Ok(NativeWidget {
                     // Extend the lifetime of the view.
                     view: ns_view.retain(),
-                    opaque: unsafe { ns_window.isOpaque() },
+                    opaque: ns_window.isOpaque(),
                 })
             }
             _ => Err(Error::IncompatibleNativeWidget),

--- a/src/platform/macos/system/connection.rs
+++ b/src/platform/macos/system/connection.rs
@@ -199,7 +199,7 @@ impl Connection {
                 Ok(NativeWidget {
                     // Extend the lifetime of the view.
                     view: ns_view.retain(),
-                    opaque: unsafe { ns_window.isOpaque() },
+                    opaque: ns_window.isOpaque(),
                 })
             }
             _ => Err(Error::IncompatibleNativeWidget),

--- a/src/platform/macos/system/surface.rs
+++ b/src/platform/macos/system/surface.rs
@@ -301,15 +301,13 @@ impl Device {
             .view
             .window()
             .expect("view must be installed in a window");
-        let logical_rect = unsafe {
-            window.convertRectFromBacking(NSRect {
-                origin: NSPoint { x: 0.0, y: 0.0 },
-                size: NSSize {
-                    width: size.width as f64,
-                    height: size.height as f64,
-                },
-            })
-        };
+        let logical_rect = window.convertRectFromBacking(NSRect {
+            origin: NSPoint { x: 0.0, y: 0.0 },
+            size: NSSize {
+                width: size.width as f64,
+                height: size.height as f64,
+            },
+        });
         let logical_size = logical_rect.size;
         let layer_size = CGSize::new(logical_size.width as f64, logical_size.height as f64);
 
@@ -457,7 +455,7 @@ impl Surface {
         }
     }
 
-    pub(crate) fn lock_data(&mut self) -> Result<SurfaceDataGuard, Error> {
+    pub(crate) fn lock_data<'a>(&'a mut self) -> Result<SurfaceDataGuard<'a>, Error> {
         if !self.access.cpu_access_allowed() {
             return Err(Error::SurfaceDataInaccessible);
         }


### PR DESCRIPTION
The `objc2-*` crate upgrades come with this as they allow removing an
`unsafe {}` block that causes a warnings when a newer version is used.
