### PR TITLE
Remove `SwapChains::destroy_all`

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -756,19 +756,6 @@ where
         Ok(())
     }
 
-    /// Destroy all the swap chains for a particular producer context.
-    /// Called by the producer.
-    pub fn destroy_all(&self, device: &Device, context: &mut Device::Context) -> Result<(), Error> {
-        if let Some(mut ids) = self.ids().remove(&device.context_id(context)) {
-            for id in ids.drain() {
-                if let Some(swap_chain) = self.table_mut().remove(&id) {
-                    swap_chain.destroy(device, context)?;
-                }
-            }
-        }
-        Ok(())
-    }
-
     /// Iterate over all the swap chains for a particular producer context.
     /// Called by the producer.
     pub fn iter(


### PR DESCRIPTION
This API is a bit dangerous because it assumes that every `SwapChain` in
the collection has the same device. I think it would be better to remove
it entirely to avoid misuse.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
