### PR TITLE
Do not run tests on i686

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,6 @@ jobs:
           - { target: x86_64-apple-darwin, os: macos-15-intel, test: true }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-24.04, test: true }
           - { target: x86_64-pc-windows-msvc, os: windows-latest, test: true }
-          - { target: i686-pc-windows-msvc, os: windows-latest, test: false }
           - { target: aarch64-pc-windows-msvc, os: windows-latest, test: false }
           - {
               target: aarch64-unknown-linux-ohos,


### PR DESCRIPTION
This platform isn't super relevant any longer, so I think it is safe to
remove it entirely from the CI to save resources.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
