### PR TITLE
Bump version to `0.11`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surfman"
 license = "MIT OR Apache-2.0 OR MPL-2.0"
 edition = "2021"
-version = "0.10.0"
+version = "0.11.0"
 authors = [
     "Patrick Walton <pcwalton@mimiga.net>",
     "Emilio Cobos Álvarez <emilio@crisal.io>",


### PR DESCRIPTION
This big version bump is necessary as we have changed the API to take a
non-`mut` `Device` in many places.
