### PR TITLE
feat: Add method to access DXGI share handle

### DIFF
--- a/src/platform/windows/angle/surface.rs
+++ b/src/platform/windows/angle/surface.rs
@@ -599,6 +599,15 @@ impl Surface {
             _ => false,
         }
     }
+
+    /// Returns the DXGI share handle if it has one.
+    #[inline]
+    pub fn share_handle(&self) -> Option<HANDLE> {
+        match self.win32_objects {
+            Win32Objects::Pbuffer { share_handle, .. } => Some(share_handle),
+            _ => None,
+        }
+    }
 }
 
 /// Represents the CPU view of the pixel data of this surface.

--- a/src/platform/windows/wgl/surface.rs
+++ b/src/platform/windows/wgl/surface.rs
@@ -660,6 +660,17 @@ impl Surface {
             Win32Objects::Widget { window_handle } => SurfaceID(window_handle as usize),
         }
     }
+
+    /// Returns the DXGI share handle if it has one.
+    #[inline]
+    pub fn share_handle(&self) -> Option<HANDLE> {
+        match self.win32_objects {
+            Win32Objects::Texture {
+                dxgi_share_handle, ..
+            } => Some(dxgi_share_handle),
+            Win32Objects::Widget { .. } => None,
+        }
+    }
 }
 
 /// Represents the CPU view of the pixel data of this surface.

--- a/src/platform/windows/wgl/surface.rs
+++ b/src/platform/windows/wgl/surface.rs
@@ -668,7 +668,7 @@ impl Surface {
             Win32Objects::Texture {
                 dxgi_share_handle, ..
             } => Some(dxgi_share_handle),
-            Win32Objects::Widget { .. } => None,
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
**Summary**
Add a public `share_handle()` accessor to `Surface` on the Windows ANGLE and WGL backends, returning the underlying DXGI shared handle (`HANDLE`) for generic (pbuffer/texture) surfaces.

**Motivation**
Consumers that need to share a surfman `Surface` with other GPU APIs (e.g. importing into a D3D12/wgpu device via `OpenSharedHandle`) currently have no way to obtain the DXGI share handle through the public API. The handle is already computed and stored internally during surface creation, but it is gated behind `pub(crate)` fields.

This is needed for DirectX rendering bridge, where ANGLE renders into a surfman surface and the backing D3D11 texture is then shared with wgpu's DX12 backend for compositing.