### PR TITLE
Bump version to 0.12.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surfman"
 license = "MIT OR Apache-2.0 OR MPL-2.0"
 edition = "2021"
-version = "0.11.0"
+version = "0.12.0"
 authors = [
     "Patrick Walton <pcwalton@mimiga.net>",
     "Emilio Cobos Álvarez <emilio@crisal.io>",


### PR DESCRIPTION
This includes the removal of the SwapChains::destroy_all, which was a public API method.