### PR TITLE
Retain recycled swapchain surfaces

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -221,11 +221,6 @@ impl<Device: DeviceAPI> SwapChainData<Device> {
             self.context_id
         );
         self.pending_surface = Some(new_front_buffer);
-        for mut surface in self.recycled_surfaces.drain(..) {
-            debug!("Destroying a surface for context {:?}", self.context_id);
-            device.destroy_surface(context, &mut surface)?;
-        }
-
         Ok(())
     }
 
@@ -279,6 +274,9 @@ impl<Device: DeviceAPI> SwapChainData<Device> {
         self.back_buffer
             .replace_surface(device, context, new_back_buffer)?;
         device.destroy_surface(context, &mut old_back_buffer)?;
+        for mut surface in self.recycled_surfaces.drain(..) {
+            device.destroy_surface(context, &mut surface)?;
+        }
         self.size = size;
         Ok(())
     }


### PR DESCRIPTION
Hi! My app is using Servo embedded and rendering high perf graphics into an offscreen canvas, and I noticed WebGL users were quickly eating large amounts of RAM until the process crashed. The app does not have this issue at all on Windows or Linux, only MacOS shows it. I traced it back to this code with Codex (gpt-5.5 xhigh), and with this change everything works perfect across all 3 platforms.

## Summary

Keep recycled same-size swapchain surfaces in the pool across swaps instead of destroying all leftovers every frame.

## Why

`SwapChainData::swap_buffers` already reuses one matching recycled surface as the next back buffer, but then drains and destroys every other recycled surface at the end of each swap. For high-frequency WebGL producers, this creates continuous surface create/destroy churn even when dimensions are stable. On macOS, where these surfaces are IOSurface/CGL-backed, that churn can show up as rapidly growing graphics footprint in long-running embedders.

The swapchain already owns these recycled surfaces and destroys them on `destroy`; this change also clears them on `resize`, where stale dimensions should be discarded.

## Verification

- `cargo check --features chains`
- Validated in Hypercolor Servo/WebGL embedder at 60 FPS: IOAccelerator graphics memory stays stable instead of growing multiple GB over minutes.