### PR TITLE
Publish 0.12.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surfman"
 license = "MIT OR Apache-2.0 OR MPL-2.0"
 edition = "2021"
-version = "0.12.1"
+version = "0.12.2"
 authors = [
     "Patrick Walton <pcwalton@mimiga.net>",
     "Emilio Cobos Álvarez <emilio@crisal.io>",


### PR DESCRIPTION
This includes a fix for preserving surface contents when resizing a
surface on macOS.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
