### PR TITLE
Add `Device::present_bound_surface` API

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -204,6 +204,13 @@ where
     /// This will be `GL_TEXTURE_2D` or `GL_TEXTURE_RECTANGLE`, depending on platform.
     fn surface_gl_texture_target(&self) -> u32;
 
+    /// Displays the contents of the currently bound surface to the screen, if
+    /// it is a widget surface.
+    ///
+    /// Widget surfaces are internally double-buffered, so changes to them don't
+    /// show up in their associated widgets until this method is called.
+    fn present_bound_surface(&self, context: &mut Self::Context) -> Result<(), Error>;
+
     /// Displays the contents of a widget surface on screen.
     ///
     /// Widget surfaces are internally double-buffered, so changes to them don't show up in their

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -323,6 +323,11 @@ macro_rules! implement_interfaces {
                 }
 
                 #[inline]
+                fn present_bound_surface(&self, context: &mut Self::Context) -> Result<(), Error> {
+                    Device::present_bound_surface(self, context)
+                }
+
+                #[inline]
                 fn present_surface(
                     &self,
                     context: &Self::Context,

--- a/src/platform/egl/context.rs
+++ b/src/platform/egl/context.rs
@@ -305,6 +305,18 @@ impl Device {
         }
     }
 
+    /// Displays the contents of the currently bound surface to the screen, if
+    /// it is a widget surface.
+    ///
+    /// Widget surfaces are internally double-buffered, so changes to them don't
+    /// show up in their associated widgets until this method is called.
+    pub fn present_bound_surface(&self, context: &mut Context) -> Result<(), Error> {
+        match &context.framebuffer {
+            Framebuffer::Surface(surface) => self.present_surface_inner(context, surface),
+            _ => Ok(()),
+        }
+    }
+
     /// Returns the attributes that the context descriptor was created with.
     pub fn context_descriptor_attributes(
         &self,

--- a/src/platform/egl/surface/android_surface.rs
+++ b/src/platform/egl/surface/android_surface.rs
@@ -209,29 +209,6 @@ impl Device {
         }
     }
 
-    /// Displays the contents of a widget surface on screen.
-    ///
-    /// Widget surfaces are internally double-buffered, so changes to them don't show up in their
-    /// associated widgets until this method is called.
-    ///
-    /// The supplied context must match the context the surface was created with, or an
-    /// `IncompatibleSurface` error is returned.
-    pub fn present_surface(&self, context: &Context, surface: &mut Surface) -> Result<(), Error> {
-        if context.id != surface.context_id {
-            return Err(Error::IncompatibleSurface);
-        }
-
-        EGL_FUNCTIONS.with(|egl| unsafe {
-            match surface.objects {
-                SurfaceObjects::Window { egl_surface } => {
-                    egl.SwapBuffers(self.egl_display, egl_surface);
-                    Ok(())
-                }
-                SurfaceObjects::HardwareBuffer { .. } => Err(Error::NoWidgetAttached),
-            }
-        })
-    }
-
     /// Resizes a widget surface.
     pub fn resize_surface(
         &self,

--- a/src/platform/egl/surface/mod.rs
+++ b/src/platform/egl/surface/mod.rs
@@ -4,7 +4,9 @@
 
 use crate::context::ContextID;
 use crate::platform::generic::egl::ffi::EGLImageKHR;
+use crate::{Context, Device, Error};
 
+use crate::platform::generic::egl::device::EGL_FUNCTIONS;
 use euclid::default::Size2D;
 use glow::Texture;
 use std::fmt::{self, Debug, Formatter};
@@ -83,5 +85,38 @@ impl Drop for Surface {
 impl Debug for SurfaceTexture {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
         write!(f, "SurfaceTexture({:?})", self.surface)
+    }
+}
+
+impl Device {
+    /// Displays the contents of a widget surface on screen.
+    ///
+    /// Widget surfaces are internally double-buffered, so changes to them don't show up in their
+    /// associated widgets until this method is called.
+    ///
+    /// The supplied context must match the context the surface was created with, or an
+    /// `IncompatibleSurface` error is returned.
+    pub fn present_surface(&self, context: &Context, surface: &mut Surface) -> Result<(), Error> {
+        self.present_surface_inner(context, surface)
+    }
+
+    pub(crate) fn present_surface_inner(
+        &self,
+        context: &Context,
+        surface: &Surface,
+    ) -> Result<(), Error> {
+        if context.id != surface.context_id {
+            return Err(Error::IncompatibleSurface);
+        }
+
+        EGL_FUNCTIONS.with(|egl| unsafe {
+            match surface.objects {
+                SurfaceObjects::Window { egl_surface } => {
+                    egl.SwapBuffers(self.egl_display, egl_surface);
+                    Ok(())
+                }
+                _ => Err(Error::NoWidgetAttached),
+            }
+        })
     }
 }

--- a/src/platform/egl/surface/ohos_surface.rs
+++ b/src/platform/egl/surface/ohos_surface.rs
@@ -211,29 +211,6 @@ impl Device {
         }
     }
 
-    /// Displays the contents of a widget surface on screen.
-    ///
-    /// Widget surfaces are internally double-buffered, so changes to them don't show up in their
-    /// associated widgets until this method is called.
-    ///
-    /// The supplied context must match the context the surface was created with, or an
-    /// `IncompatibleSurface` error is returned.
-    pub fn present_surface(&self, context: &Context, surface: &mut Surface) -> Result<(), Error> {
-        if context.id != surface.context_id {
-            return Err(Error::IncompatibleSurface);
-        }
-
-        EGL_FUNCTIONS.with(|egl| unsafe {
-            match surface.objects {
-                SurfaceObjects::Window { egl_surface } => {
-                    egl.SwapBuffers(self.egl_display, egl_surface);
-                    Ok(())
-                }
-                SurfaceObjects::HardwareBuffer { .. } => Err(Error::NoWidgetAttached),
-            }
-        })
-    }
-
     /// Resizes a widget surface.
     pub fn resize_surface(
         &self,

--- a/src/platform/generic/egl/context.rs
+++ b/src/platform/generic/egl/context.rs
@@ -250,6 +250,13 @@ impl EGLBackedContext {
         Ok(Some(surface))
     }
 
+    pub fn present_bound_surface(&self, egl_display: EGLDisplay) -> Result<(), Error> {
+        match &self.framebuffer {
+            Framebuffer::Surface(surface) => surface.present(egl_display, self.egl_context),
+            Framebuffer::None | Framebuffer::External(_) => Ok(()),
+        }
+    }
+
     pub(crate) fn surface_info(&self) -> Result<Option<SurfaceInfo>, Error> {
         match self.framebuffer {
             Framebuffer::None => Ok(None),

--- a/src/platform/generic/multi/context.rs
+++ b/src/platform/generic/multi/context.rs
@@ -264,6 +264,23 @@ where
         }
     }
 
+    /// Displays the contents of the currently bound surface to the screen, if
+    /// it is a widget surface.
+    ///
+    /// Widget surfaces are internally double-buffered, so changes to them don't
+    /// show up in their associated widgets until this method is called.
+    pub fn present_bound_surface(&self, context: &mut Context<Def, Alt>) -> Result<(), Error> {
+        match (self, context) {
+            (Device::Default(device), Context::Default(context)) => {
+                device.present_bound_surface(context)
+            }
+            (Device::Alternate(device), Context::Alternate(context)) => {
+                device.present_bound_surface(context)
+            }
+            _ => Err(Error::IncompatibleContext),
+        }
+    }
+
     /// Returns the attributes that the context descriptor was created with.
     pub fn context_descriptor_attributes(
         &self,

--- a/src/platform/generic/multi/device.rs
+++ b/src/platform/generic/multi/device.rs
@@ -285,6 +285,11 @@ where
     }
 
     #[inline]
+    fn present_bound_surface(&self, context: &mut Context<Def, Alt>) -> Result<(), Error> {
+        Device::present_bound_surface(self, context)
+    }
+
+    #[inline]
     fn present_surface(
         &self,
         context: &Context<Def, Alt>,

--- a/src/platform/macos/cgl/context.rs
+++ b/src/platform/macos/cgl/context.rs
@@ -394,6 +394,19 @@ impl Device {
         }
     }
 
+    /// Displays the contents of the currently bound surface to the screen, if
+    /// it is a widget surface.
+    ///
+    /// Widget surfaces are internally double-buffered, so changes to them don't
+    /// show up in their associated widgets until this method is called.
+    pub fn present_bound_surface(&self, context: &mut Context) -> Result<(), Error> {
+        if let Framebuffer::Surface(surface) = &mut context.framebuffer {
+            self.0.present_surface(&mut surface.system_surface)?;
+            surface.bind_to_texture(&context.gl);
+        }
+        Ok(())
+    }
+
     /// Returns the attributes that the context descriptor was created with.
     pub fn context_descriptor_attributes(
         &self,

--- a/src/platform/macos/cgl/surface.rs
+++ b/src/platform/macos/cgl/surface.rs
@@ -109,6 +109,20 @@ fn surface_bind_to_gl_texture(surface: &IOSurfaceRef, width: i32, height: i32, h
     }
 }
 
+impl Surface {
+    pub(crate) fn bind_to_texture(&self, gl: &Rc<Gl>) {
+        let size = self.system_surface.size;
+        unsafe { gl.bind_texture(gl::TEXTURE_RECTANGLE, self.texture_object) };
+        surface_bind_to_gl_texture(
+            &self.system_surface.io_surface,
+            size.width,
+            size.height,
+            true,
+        );
+        unsafe { gl.bind_texture(gl::TEXTURE_RECTANGLE, None) };
+    }
+}
+
 impl Device {
     /// Creates either a generic or a widget surface, depending on the supplied surface type.
     ///
@@ -324,20 +338,7 @@ impl Device {
     /// `IncompatibleSurface` error is returned.
     pub fn present_surface(&self, context: &Context, surface: &mut Surface) -> Result<(), Error> {
         self.0.present_surface(&mut surface.system_surface)?;
-
-        let gl = &context.gl;
-        unsafe {
-            let size = surface.system_surface.size;
-            gl.bind_texture(gl::TEXTURE_RECTANGLE, surface.texture_object);
-            surface_bind_to_gl_texture(
-                &surface.system_surface.io_surface,
-                size.width,
-                size.height,
-                true,
-            );
-            gl.bind_texture(gl::TEXTURE_RECTANGLE, None);
-        }
-
+        surface.bind_to_texture(&context.gl);
         Ok(())
     }
 

--- a/src/platform/unix/generic/context.rs
+++ b/src/platform/unix/generic/context.rs
@@ -221,6 +221,17 @@ impl Device {
         }
     }
 
+    /// Displays the contents of the currently bound surface to the screen, if
+    /// it is a widget surface.
+    ///
+    /// Widget surfaces are internally double-buffered, so changes to them don't
+    /// show up in their associated widgets until this method is called.
+    pub fn present_bound_surface(&self, context: &mut Context) -> Result<(), Error> {
+        context
+            .0
+            .present_bound_surface(self.native_connection.egl_display)
+    }
+
     /// Returns a unique ID representing a context.
     ///
     /// This ID is unique to all currently-allocated contexts. If you destroy a context and create

--- a/src/platform/unix/wayland/context.rs
+++ b/src/platform/unix/wayland/context.rs
@@ -219,6 +219,17 @@ impl Device {
         }
     }
 
+    /// Displays the contents of the currently bound surface to the screen, if
+    /// it is a widget surface.
+    ///
+    /// Widget surfaces are internally double-buffered, so changes to them don't
+    /// show up in their associated widgets until this method is called.
+    pub fn present_bound_surface(&self, context: &mut Context) -> Result<(), Error> {
+        context
+            .0
+            .present_bound_surface(self.native_connection.egl_display)
+    }
+
     /// Returns a unique ID representing a context.
     ///
     /// This ID is unique to all currently-allocated contexts. If you destroy a context and create

--- a/src/platform/unix/x11/context.rs
+++ b/src/platform/unix/x11/context.rs
@@ -219,6 +219,17 @@ impl Device {
         }
     }
 
+    /// Displays the contents of the currently bound surface to the screen, if
+    /// it is a widget surface.
+    ///
+    /// Widget surfaces are internally double-buffered, so changes to them don't
+    /// show up in their associated widgets until this method is called.
+    pub fn present_bound_surface(&self, context: &mut Context) -> Result<(), Error> {
+        context
+            .0
+            .present_bound_surface(self.native_connection.egl_display)
+    }
+
     /// Returns a unique ID representing a context.
     ///
     /// This ID is unique to all currently-allocated contexts. If you destroy a context and create

--- a/src/platform/windows/angle/context.rs
+++ b/src/platform/windows/angle/context.rs
@@ -359,6 +359,18 @@ impl Device {
         Ok(Some(surface))
     }
 
+    /// Displays the contents of the currently bound surface to the screen, if
+    /// it is a widget surface.
+    ///
+    /// Widget surfaces are internally double-buffered, so changes to them don't
+    /// show up in their associated widgets until this method is called.
+    pub fn present_bound_surface(&self, context: &mut Context) -> Result<(), Error> {
+        match &context.framebuffer {
+            Framebuffer::Surface(surface) => surface.present(self),
+            _ => Ok(()),
+        }
+    }
+
     /// Returns a unique ID representing a context.
     ///
     /// This ID is unique to all currently-allocated contexts. If you destroy a context and create

--- a/src/platform/windows/angle/surface.rs
+++ b/src/platform/windows/angle/surface.rs
@@ -532,16 +532,7 @@ impl Device {
     /// The supplied context must match the context the surface was created with, or an
     /// `IncompatibleSurface` error is returned.
     pub fn present_surface(&self, _: &Context, surface: &mut Surface) -> Result<(), Error> {
-        match surface.win32_objects {
-            Win32Objects::Window { .. } => {}
-            _ => return Err(Error::NoWidgetAttached),
-        }
-
-        EGL_FUNCTIONS.with(|egl| unsafe {
-            let ok = egl.SwapBuffers(self.egl_display, surface.egl_surface);
-            assert_ne!(ok, egl::FALSE);
-            Ok(())
-        })
+        surface.present(self)
     }
 
     /// Resizes a widget surface.
@@ -607,6 +598,19 @@ impl Surface {
             Win32Objects::Pbuffer { share_handle, .. } => Some(share_handle),
             _ => None,
         }
+    }
+
+    pub(crate) fn present(&self, device: &Device) -> Result<(), Error> {
+        match self.win32_objects {
+            Win32Objects::Window { .. } => {}
+            _ => return Err(Error::NoWidgetAttached),
+        }
+
+        EGL_FUNCTIONS.with(|egl| unsafe {
+            let ok = egl.SwapBuffers(device.egl_display, self.egl_surface);
+            assert_ne!(ok, egl::FALSE);
+            Ok(())
+        })
     }
 }
 

--- a/src/platform/windows/wgl/context.rs
+++ b/src/platform/windows/wgl/context.rs
@@ -578,6 +578,18 @@ impl Device {
         }
     }
 
+    /// Displays the contents of the currently bound surface to the screen, if
+    /// it is a widget surface.
+    ///
+    /// Widget surfaces are internally double-buffered, so changes to them don't
+    /// show up in their associated widgets until this method is called.
+    pub fn present_bound_surface(&self, context: &mut Context) -> Result<(), Error> {
+        match &context.framebuffer {
+            Framebuffer::Surface(surface) => surface.present(),
+            _ => Ok(()),
+        }
+    }
+
     pub(crate) fn get_context_dc<'a>(&self, context: &'a Context) -> DCGuard<'a> {
         unsafe {
             match context.framebuffer {

--- a/src/platform/windows/wgl/surface.rs
+++ b/src/platform/windows/wgl/surface.rs
@@ -595,18 +595,7 @@ impl Device {
     /// The supplied context must match the context the surface was created with, or an
     /// `IncompatibleSurface` error is returned.
     pub fn present_surface(&self, _: &Context, surface: &mut Surface) -> Result<(), Error> {
-        let window_handle = match surface.win32_objects {
-            Win32Objects::Widget { window_handle } => window_handle,
-            _ => return Err(Error::NoWidgetAttached),
-        };
-
-        unsafe {
-            let dc = winuser::GetDC(window_handle);
-            let ok = wingdi::SwapBuffers(dc);
-            assert_ne!(ok, FALSE);
-            winuser::ReleaseDC(window_handle, dc);
-            Ok(())
-        }
+        surface.present()
     }
 
     /// Resizes a widget surface.
@@ -669,6 +658,21 @@ impl Surface {
                 dxgi_share_handle, ..
             } => Some(dxgi_share_handle),
             _ => None,
+        }
+    }
+
+    pub(crate) fn present(&self) -> Result<(), Error> {
+        let window_handle = match self.win32_objects {
+            Win32Objects::Widget { window_handle } => window_handle,
+            _ => return Err(Error::NoWidgetAttached),
+        };
+
+        unsafe {
+            let dc = winuser::GetDC(window_handle);
+            let ok = wingdi::SwapBuffers(dc);
+            assert_ne!(ok, FALSE);
+            winuser::ReleaseDC(window_handle, dc);
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
In order to present a widget surface that is bound to a context, a user
of `surfman` must currently:

 - Unbind the surface
 - Present the surface
 - Rebind the surface

On EGL platforms unbinding the surface calls:

```
eglMakeCurrent(egldisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, egl_context);
```

The expected resize story for Wayland is:

1. The server calls the application's `configure` callback with the new
   window size.
2. The application calls `wl_egl_window_resize`.
3. The application waits for the next frame callback.
4. The application redraws into the surface at the new size.

Notably, `wl_egl_window_resize` *does not* resize the surface
immediately. Resizing happens later in a driver-defined way.

In Servo we handle this by:

1. Receiving the `winit` resize signal.
2. Unbinding the surface (calls `eglMakeCurrent` with `NO_SURFACE`
   values).
3. Resizing the surface (calls `wl_egl_window_resize`)
4. Rebinding the surface.
5. Waiting for the redraw signal from `winit` (presumably triggered by
   the Wayland frame callback).
6. Repainting the contents at the new size using OpenGL.
7. Unbinding the surface
8. Presenting the surface (calls `eglSwapBuffers`)
9. Rebinding the surface

Either calling `eglMakeCurrent` before calling `eglSwapBuffers` or
calling `eglSwapBuffers` with no surface bound, means that the driver is
failing to properly resize the surface after `wl_egl_window_resize`. In
general, constantly having to call `eglMakeCurrent` multiple times in
order to call `eglSwapBuffers` is both disruptive and not how typical
OpenGL applications work.

So this change adds a way to present the surface without having to first
unbind it from the context. A followup change will address resizing. It
does not make any changes to existing APIs.
