### PR TITLE
Add a `Device::resize_bound_surface` API

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -224,6 +224,13 @@ where
         surface: &mut Self::Surface,
     ) -> Result<(), Error>;
 
+    /// If the currently bound surface is a widget surface, resize it,
+    fn resize_bound_surface(
+        &self,
+        context: &mut Self::Context,
+        size: Size2D<i32>,
+    ) -> Result<(), Error>;
+
     /// Resizes a widget surface.
     fn resize_surface(
         &self,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -337,6 +337,15 @@ macro_rules! implement_interfaces {
                 }
 
                 #[inline]
+                fn resize_bound_surface(
+                    &self,
+                    context: &mut Context,
+                    size: Size2D<i32>,
+                ) -> Result<(), Error> {
+                    Device::resize_bound_surface(self, context, size)
+                }
+
+                #[inline]
                 fn resize_surface(
                     &self,
                     context: &Context,

--- a/src/platform/egl/context.rs
+++ b/src/platform/egl/context.rs
@@ -15,6 +15,7 @@ use crate::platform::generic::egl::error::ToWindowingApiError;
 use crate::platform::generic::egl::surface::ExternalEGLSurfaces;
 use crate::surface::Framebuffer;
 use crate::{ContextAttributes, Error, Gl, SurfaceInfo};
+use euclid::default::Size2D;
 
 use std::mem;
 use std::os::raw::c_void;
@@ -315,6 +316,18 @@ impl Device {
             Framebuffer::Surface(surface) => self.present_surface_inner(context, surface),
             _ => Ok(()),
         }
+    }
+
+    /// If the currently bound surface is a widget surface, resize it,
+    pub fn resize_bound_surface(
+        &self,
+        context: &mut Context,
+        size: Size2D<i32>,
+    ) -> Result<(), Error> {
+        if let Framebuffer::Surface(surface) = &mut context.framebuffer {
+            surface.resize(size);
+        }
+        Ok(())
     }
 
     /// Returns the attributes that the context descriptor was created with.

--- a/src/platform/egl/surface/android_surface.rs
+++ b/src/platform/egl/surface/android_surface.rs
@@ -209,17 +209,6 @@ impl Device {
         }
     }
 
-    /// Resizes a widget surface.
-    pub fn resize_surface(
-        &self,
-        _context: &Context,
-        surface: &mut Surface,
-        size: Size2D<i32>,
-    ) -> Result<(), Error> {
-        surface.size = size;
-        Ok(())
-    }
-
     #[allow(non_snake_case)]
     unsafe fn create_egl_image(
         &self,

--- a/src/platform/egl/surface/mod.rs
+++ b/src/platform/egl/surface/mod.rs
@@ -82,6 +82,12 @@ impl Drop for Surface {
     }
 }
 
+impl Surface {
+    pub(crate) fn resize(&mut self, size: Size2D<i32>) {
+        self.size = size;
+    }
+}
+
 impl Debug for SurfaceTexture {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
         write!(f, "SurfaceTexture({:?})", self.surface)
@@ -118,5 +124,16 @@ impl Device {
                 _ => Err(Error::NoWidgetAttached),
             }
         })
+    }
+
+    /// Resizes a widget surface.
+    pub fn resize_surface(
+        &self,
+        _context: &Context,
+        surface: &mut Surface,
+        size: Size2D<i32>,
+    ) -> Result<(), Error> {
+        surface.resize(size);
+        Ok(())
     }
 }

--- a/src/platform/egl/surface/ohos_surface.rs
+++ b/src/platform/egl/surface/ohos_surface.rs
@@ -211,17 +211,6 @@ impl Device {
         }
     }
 
-    /// Resizes a widget surface.
-    pub fn resize_surface(
-        &self,
-        _context: &Context,
-        surface: &mut Surface,
-        size: Size2D<i32>,
-    ) -> Result<(), Error> {
-        surface.size = size;
-        Ok(())
-    }
-
     #[allow(non_snake_case)]
     unsafe fn create_egl_image(
         &self,

--- a/src/platform/generic/egl/context.rs
+++ b/src/platform/generic/egl/context.rs
@@ -13,6 +13,7 @@ use crate::egl::types::{EGLConfig, EGLContext, EGLDisplay, EGLSurface, EGLint};
 use crate::surface::Framebuffer;
 use crate::{ContextAttributeFlags, ContextAttributes, ContextID, Error, GLApi, GLVersion};
 use crate::{Gl, SurfaceInfo};
+use euclid::default::Size2D;
 use glow::HasContext;
 
 use std::ffi::CString;
@@ -29,7 +30,7 @@ pub(crate) struct EGLBackedContext {
     pub(crate) egl_context: EGLContext,
     pub(crate) id: ContextID,
     pbuffer: EGLSurface,
-    framebuffer: Framebuffer<EGLBackedSurface, ExternalEGLSurfaces>,
+    pub(crate) framebuffer: Framebuffer<EGLBackedSurface, ExternalEGLSurfaces>,
     context_is_owned: bool,
 }
 
@@ -274,11 +275,18 @@ impl EGLBackedContext {
         Ok(Some(surface))
     }
 
-    pub fn present_bound_surface(&self, egl_display: EGLDisplay) -> Result<(), Error> {
+    pub(crate) fn present_bound_surface(&self, egl_display: EGLDisplay) -> Result<(), Error> {
         match &self.framebuffer {
             Framebuffer::Surface(surface) => surface.present(egl_display, self.egl_context),
             Framebuffer::None | Framebuffer::External(_) => Ok(()),
         }
+    }
+
+    pub(crate) fn resize_bound_surface(&mut self, size: Size2D<i32>) -> Result<(), Error> {
+        if let Framebuffer::Surface(surface) = &mut self.framebuffer {
+            surface.resize(size);
+        }
+        Ok(())
     }
 
     pub(crate) fn surface_info(&self) -> Result<Option<SurfaceInfo>, Error> {

--- a/src/platform/generic/egl/surface.rs
+++ b/src/platform/generic/egl/surface.rs
@@ -353,6 +353,10 @@ impl EGLBackedSurface {
             EGLSurfaceObjects::TextureImage { .. } => ExternalEGLSurfaces::default(),
         }
     }
+
+    pub(crate) fn resize(&mut self, size: Size2D<i32>) {
+        self.size = size;
+    }
 }
 
 impl EGLSurfaceTexture {

--- a/src/platform/generic/multi/context.rs
+++ b/src/platform/generic/multi/context.rs
@@ -2,6 +2,8 @@
 //
 //! A context abstraction that allows the choice of backends dynamically.
 
+use euclid::default::Size2D;
+
 use super::device::Device;
 use super::surface::Surface;
 use crate::device::Device as DeviceInterface;
@@ -276,6 +278,23 @@ where
             }
             (Device::Alternate(device), Context::Alternate(context)) => {
                 device.present_bound_surface(context)
+            }
+            _ => Err(Error::IncompatibleContext),
+        }
+    }
+
+    /// Resizes the currently bound surface.
+    pub fn resize_bound_surface(
+        &self,
+        context: &mut Context<Def, Alt>,
+        size: Size2D<i32>,
+    ) -> Result<(), Error> {
+        match (self, context) {
+            (Device::Default(device), Context::Default(context)) => {
+                device.resize_bound_surface(context, size)
+            }
+            (Device::Alternate(device), Context::Alternate(context)) => {
+                device.resize_bound_surface(context, size)
             }
             _ => Err(Error::IncompatibleContext),
         }

--- a/src/platform/generic/multi/device.rs
+++ b/src/platform/generic/multi/device.rs
@@ -290,6 +290,15 @@ where
     }
 
     #[inline]
+    fn resize_bound_surface(
+        &self,
+        context: &mut Self::Context,
+        size: Size2D<i32>,
+    ) -> Result<(), Error> {
+        Device::resize_bound_surface(&self, context, size)
+    }
+
+    #[inline]
     fn present_surface(
         &self,
         context: &Context<Def, Alt>,

--- a/src/platform/macos/cgl/context.rs
+++ b/src/platform/macos/cgl/context.rs
@@ -18,6 +18,7 @@ use cgl::{
 };
 use cgl::{CGLGetCurrentContext, CGLGetPixelFormat, CGLPixelFormatAttribute, CGLPixelFormatObj};
 use cgl::{CGLReleasePixelFormat, CGLRetainPixelFormat, CGLSetCurrentContext};
+use euclid::default::Size2D;
 use glow::HasContext;
 use objc2_core_foundation::{CFBundle, CFRetained, CFString};
 use std::mem;
@@ -403,6 +404,21 @@ impl Device {
         if let Framebuffer::Surface(surface) = &mut context.framebuffer {
             self.0.present_surface(&mut surface.system_surface)?;
             surface.bind_to_texture(&context.gl);
+        }
+        Ok(())
+    }
+
+    /// If the currently bound surface is a widget surface, resize it,
+    pub fn resize_bound_surface(
+        &self,
+        context: &mut Context,
+        size: Size2D<i32>,
+    ) -> Result<(), Error> {
+        let _guard = self.temporarily_make_context_current(context);
+        let context_descriptor = self.context_descriptor(context);
+        let context_attributes = self.context_descriptor_attributes(&context_descriptor);
+        if let Framebuffer::Surface(surface) = &mut context.framebuffer {
+            return self.resize_inner(surface, size, &context.gl, context_attributes);
         }
         Ok(())
     }

--- a/src/platform/macos/cgl/surface.rs
+++ b/src/platform/macos/cgl/surface.rs
@@ -8,7 +8,10 @@ use crate::context::ContextID;
 use crate::gl_utils;
 use crate::platform::macos::system::surface::Surface as SystemSurface;
 use crate::renderbuffers::Renderbuffers;
-use crate::{gl, Error, SurfaceAccess, SurfaceID, SurfaceInfo, SurfaceType, WindowingApiError};
+use crate::{
+    gl, ContextAttributes, Error, SurfaceAccess, SurfaceID, SurfaceInfo, SurfaceType,
+    WindowingApiError,
+};
 use cgl::{kCGLNoError, CGLErrorString, CGLGetCurrentContext, CGLTexImageIOSurface2D, GLenum};
 use glow::Context as Gl;
 
@@ -354,15 +357,22 @@ impl Device {
         }
 
         let _guard = self.temporarily_make_context_current(context);
-        let _guard =
-            self.temporarily_bind_framebuffer(context.gl.clone(), surface.framebuffer_object);
+        let context_descriptor = self.context_descriptor(context);
+        let context_attributes = self.context_descriptor_attributes(&context_descriptor);
+        self.resize_inner(surface, size, &context.gl, context_attributes)
+    }
+
+    pub(crate) fn resize_inner(
+        &self,
+        surface: &mut Surface,
+        size: Size2D<i32>,
+        gl: &Rc<gl::Context>,
+        context_attributes: ContextAttributes,
+    ) -> Result<(), Error> {
+        let _guard = self.temporarily_bind_framebuffer(gl.clone(), surface.framebuffer_object);
 
         self.0.resize_surface(&mut surface.system_surface, size)?;
 
-        let context_descriptor = self.context_descriptor(context);
-        let context_attributes = self.context_descriptor_attributes(&context_descriptor);
-
-        let gl = &context.gl;
         unsafe {
             // Recreate the GL texture and bind it to the FBO
             let texture_object =

--- a/src/platform/unix/generic/context.rs
+++ b/src/platform/unix/generic/context.rs
@@ -2,6 +2,8 @@
 //
 //! OpenGL rendering contexts on surfaceless Mesa.
 
+use euclid::default::Size2D;
+
 use super::device::Device;
 use super::surface::Surface;
 use crate::context::ContextID;
@@ -230,6 +232,15 @@ impl Device {
         context
             .0
             .present_bound_surface(self.native_connection.egl_display)
+    }
+
+    /// Resizes a widget surface.
+    pub fn resize_bound_surface(
+        &self,
+        context: &mut Context,
+        size: Size2D<i32>,
+    ) -> Result<(), Error> {
+        context.0.resize_bound_surface(size)
     }
 
     /// Returns a unique ID representing a context.

--- a/src/platform/unix/wayland/context.rs
+++ b/src/platform/unix/wayland/context.rs
@@ -2,12 +2,15 @@
 //
 //! OpenGL rendering contexts on Wayland.
 
+use euclid::default::Size2D;
+
 use super::device::Device;
 use super::surface::Surface;
 use crate::context::ContextID;
 use crate::egl;
 use crate::egl::types::EGLint;
 use crate::platform::generic::egl::context::{self, CurrentContextGuard, EGLBackedContext};
+use crate::surface::Framebuffer;
 use crate::{ContextAttributes, Error, Gl, SurfaceInfo};
 
 use std::os::raw::c_void;
@@ -228,6 +231,18 @@ impl Device {
         context
             .0
             .present_bound_surface(self.native_connection.egl_display)
+    }
+
+    /// If the currently bound surface is a widget surface, resize it,
+    pub fn resize_bound_surface(
+        &self,
+        context: &mut Context,
+        size: Size2D<i32>,
+    ) -> Result<(), Error> {
+        match &mut context.0.framebuffer {
+            Framebuffer::Surface(surface) => surface.resize_for_wayland(size),
+            _ => Ok(()),
+        }
     }
 
     /// Returns a unique ID representing a context.

--- a/src/platform/unix/wayland/surface.rs
+++ b/src/platform/unix/wayland/surface.rs
@@ -214,18 +214,7 @@ impl Device {
         surface: &mut Surface,
         size: Size2D<i32>,
     ) -> Result<(), Error> {
-        let wayland_egl_window = surface.0.native_window()? as *mut c_void as *mut wl_egl_window;
-        unsafe {
-            (wayland_egl_handle().wl_egl_window_resize)(
-                wayland_egl_window,
-                size.width,
-                size.height,
-                0,
-                0,
-            )
-        };
-        surface.0.size = size;
-        Ok(())
+        surface.0.resize_for_wayland(size)
     }
 
     /// Returns a pointer to the underlying surface data for reading or writing by the CPU.
@@ -264,4 +253,21 @@ impl Device {
 /// Represents the CPU view of the pixel data of this surface.
 pub struct SurfaceDataGuard<'a> {
     phantom: PhantomData<&'a ()>,
+}
+
+impl EGLBackedSurface {
+    pub(crate) fn resize_for_wayland(&mut self, size: Size2D<i32>) -> Result<(), Error> {
+        let wayland_egl_window = self.native_window()? as *mut c_void as *mut wl_egl_window;
+        unsafe {
+            (wayland_egl_handle().wl_egl_window_resize)(
+                wayland_egl_window,
+                size.width,
+                size.height,
+                0,
+                0,
+            )
+        };
+        self.resize(size);
+        Ok(())
+    }
 }

--- a/src/platform/unix/x11/context.rs
+++ b/src/platform/unix/x11/context.rs
@@ -2,6 +2,8 @@
 //
 //! OpenGL rendering contexts on X11 via EGL.
 
+use euclid::default::Size2D;
+
 use super::device::Device;
 use super::surface::Surface;
 use crate::context::ContextID;
@@ -228,6 +230,15 @@ impl Device {
         context
             .0
             .present_bound_surface(self.native_connection.egl_display)
+    }
+
+    /// If the currently bound surface is a widget surface, resize it,
+    pub fn resize_bound_surface(
+        &self,
+        context: &mut Context,
+        size: Size2D<i32>,
+    ) -> Result<(), Error> {
+        context.0.resize_bound_surface(size)
     }
 
     /// Returns a unique ID representing a context.

--- a/src/platform/unix/x11/surface.rs
+++ b/src/platform/unix/x11/surface.rs
@@ -216,7 +216,7 @@ impl Device {
         surface: &mut Surface,
         size: Size2D<i32>,
     ) -> Result<(), Error> {
-        surface.0.size = size;
+        surface.0.resize(size);
         Ok(())
     }
 

--- a/src/platform/windows/angle/context.rs
+++ b/src/platform/windows/angle/context.rs
@@ -13,6 +13,7 @@ use crate::platform::generic::egl::error::ToWindowingApiError;
 use crate::platform::generic::egl::surface::ExternalEGLSurfaces;
 use crate::surface::Framebuffer;
 use crate::{ContextAttributes, Error, Gl, SurfaceInfo};
+use euclid::default::Size2D;
 
 use glow::HasContext;
 use std::mem;
@@ -374,6 +375,18 @@ impl Device {
             Framebuffer::Surface(surface) => surface.present(self),
             _ => Ok(()),
         }
+    }
+
+    /// If the currently bound surface is a widget surface, resize it,
+    pub fn resize_bound_surface(
+        &self,
+        context: &mut Context,
+        size: Size2D<i32>,
+    ) -> Result<(), Error> {
+        if let Framebuffer::Surface(surface) = &mut context.framebuffer {
+            surface.resize(size);
+        }
+        Ok(())
     }
 
     /// Returns a unique ID representing a context.

--- a/src/platform/windows/angle/surface.rs
+++ b/src/platform/windows/angle/surface.rs
@@ -542,7 +542,7 @@ impl Device {
         surface: &mut Surface,
         size: Size2D<i32>,
     ) -> Result<(), Error> {
-        surface.size = size;
+        surface.resize(size);
         Ok(())
     }
 
@@ -611,6 +611,10 @@ impl Surface {
             assert_ne!(ok, egl::FALSE);
             Ok(())
         })
+    }
+
+    pub(crate) fn resize(&mut self, size: Size2D<i32>) {
+        self.size = size;
     }
 }
 

--- a/src/platform/windows/wgl/context.rs
+++ b/src/platform/windows/wgl/context.rs
@@ -14,6 +14,7 @@ type GLenum = c_uint;
 type GLint = c_int;
 type GLuint = c_uint;
 use crate::Gl;
+use euclid::default::Size2D;
 use glow::HasContext;
 use std::borrow::Cow;
 use std::ffi::{CStr, CString};
@@ -588,6 +589,18 @@ impl Device {
             Framebuffer::Surface(surface) => surface.present(),
             _ => Ok(()),
         }
+    }
+
+    /// If the currently bound surface is a widget surface, resize it,
+    pub fn resize_bound_surface(
+        &self,
+        context: &mut Context,
+        size: Size2D<i32>,
+    ) -> Result<(), Error> {
+        if let Framebuffer::Surface(surface) = &mut context.framebuffer {
+            surface.resize(size);
+        }
+        Ok(())
     }
 
     pub(crate) fn get_context_dc<'a>(&self, context: &'a Context) -> DCGuard<'a> {

--- a/src/platform/windows/wgl/surface.rs
+++ b/src/platform/windows/wgl/surface.rs
@@ -605,7 +605,7 @@ impl Device {
         surface: &mut Surface,
         size: Size2D<i32>,
     ) -> Result<(), Error> {
-        surface.size = size;
+        surface.resize(size);
         Ok(())
     }
 
@@ -674,6 +674,10 @@ impl Surface {
             winuser::ReleaseDC(window_handle, dc);
             Ok(())
         }
+    }
+
+    pub(crate) fn resize(&mut self, size: Size2D<i32>) {
+        self.size = size;
     }
 }
 


### PR DESCRIPTION
Much like #361, this change adds a `Device::resize_bound_surface` API so
that widget surfaces can be resized without introducing a spurious
`eglMakeCurrent` with `NO_SURFACE`. This will greatly improve resizing
behavior in Servo.
