### PR TITLE
Remove duplicate `eglDestroyContext` call in angle `Device::destroy_context`

### DIFF
--- a/src/platform/windows/angle/context.rs
+++ b/src/platform/windows/angle/context.rs
@@ -174,7 +174,6 @@ impl Device {
 
             if context.context_is_owned {
                 let result = egl.DestroyContext(self.egl_display, context.egl_context);
-                egl.DestroyContext(self.egl_display, context.egl_context);
                 assert_ne!(result, egl::FALSE);
             }
 


### PR DESCRIPTION
It's quite likely that this duplicate `eglDestroyContext` call is
causing the Windows CI to hang. This change removes the duplicate call
to context destruction.
