### PR TITLE
Call `eglReleaseTexImage` in ANGLE `Device::destroy_surface_texture`

### DIFF
--- a/src/platform/windows/angle/surface.rs
+++ b/src/platform/windows/angle/surface.rs
@@ -500,6 +500,11 @@ impl Device {
             }
 
             EGL_FUNCTIONS.with(|egl| {
+                egl.ReleaseTexImage(
+                    self.egl_display,
+                    surface_texture.local_egl_surface,
+                    egl::BACK_BUFFER as _,
+                );
                 egl.DestroySurface(self.egl_display, surface_texture.local_egl_surface);
             })
         }


### PR DESCRIPTION
As we called `eglBindTexImage` when creating the surface texture, we
should call `eglReleaseTexImage` in the same way when releasing it.

Fixes: #189.
