### PR TITLE
Use `macos-15` GitHub runner image and stop using `macos-15-intel`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { target: aarch64-apple-darwin, os: macos-14, test: true }
-          - { target: x86_64-apple-darwin, os: macos-15-intel, test: true }
+          - { target: aarch64-apple-darwin, os: macos-15, test: true }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-24.04, test: true }
           - { target: x86_64-pc-windows-msvc, os: windows-latest, test: true }
           - { target: aarch64-pc-windows-msvc, os: windows-latest, test: false }


### PR DESCRIPTION
This is an attempt to unstick the bots which seems to be stalled for
some days now.
