### PR TITLE
`glFlush` before presenting a bound surface on CGL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surfman"
 license = "MIT OR Apache-2.0 OR MPL-2.0"
 edition = "2021"
-version = "0.12.3"
+version = "0.12.4"
 authors = [
     "Patrick Walton <pcwalton@mimiga.net>",
     "Emilio Cobos Álvarez <emilio@crisal.io>",

--- a/src/cgl/device.rs
+++ b/src/cgl/device.rs
@@ -370,6 +370,12 @@ impl Device {
     /// show up in their associated widgets until this method is called.
     pub fn present_bound_surface(&self, context: &mut Context) -> Result<(), Error> {
         if let Framebuffer::Surface(surface) = &mut context.framebuffer {
+            // Presenting the surface is not a GL operation on macOS, it's just
+            // CoreAnimation and IOSurface management. This means that it will
+            // leave any unprocessed OpenGL commands in the pipeline. Flushing
+            // here ensures that doesn't happen.
+            unsafe { context.gl.flush() };
+
             self.0.present_surface(&mut surface.system_surface)?;
             surface.bind_to_texture(&context.gl);
         }


### PR DESCRIPTION
The old API (unbinding, presenting, binding) caused a flush
incidentally, but the new API does not. Flushes are necessary on macOS
only due to the fact that presenting is a CoreAnimation-only concept.
Without flushing the OpenGL commands they might not make it to the GPU
before the CoreAnimation work. The flush ensures they do.

Also bump the version, so that Servo can take advantage of this fix
immediately.
