### PR TITLE
Bump major version to '0.13'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surfman"
 license = "MIT OR Apache-2.0 OR MPL-2.0"
 edition = "2021"
-version = "0.12.5"
+version = "0.13.0"
 authors = [
     "Patrick Walton <pcwalton@mimiga.net>",
     "Emilio Cobos Álvarez <emilio@crisal.io>",


### PR DESCRIPTION
In https://github.com/servo/servo/pull/45599, it was found that the recent refactors in surfman have changed the module paths for some public types used by Servo.

Since this is a breaking change, bump the major version.

Testing: Tested with a patched Servo to confirm there are no more compilation issues due to the refactor.